### PR TITLE
UI polish: disappearing messages z-index, staged uploads, profile popout, invite dismiss

### DIFF
--- a/client/src/renderer/src/components/chat/MessageInput.tsx
+++ b/client/src/renderer/src/components/chat/MessageInput.tsx
@@ -15,7 +15,10 @@ import { useAuthStore } from '../../stores/authStore'
 import EmojiPicker from './EmojiPicker'
 import MentionAutocomplete from './MentionAutocomplete'
 import ComposerShell from './message/ComposerShell'
+import type { StagedFile } from './message/ComposerShell'
 import { formatCustomEmojiToken } from '../../utils/emoji'
+
+let stagedIdCounter = 0
 
 export default function MessageInput(): React.JSX.Element {
   const [content, setContent] = useState('')
@@ -23,6 +26,7 @@ export default function MessageInput(): React.JSX.Element {
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const [mentionStart, setMentionStart] = useState(0)
   const [uploading, setUploading] = useState(false)
+  const [stagedFiles, setStagedFiles] = useState<StagedFile[]>([])
   const activeChannelId = useServerStore((s) => s.activeChannelId)
   const sendMessage = useMessageStore((s) => s.sendMessage)
   const sendTypingStart = useMessageStore((s) => s.sendTypingStart)
@@ -57,12 +61,118 @@ export default function MessageInput(): React.JSX.Element {
     }, 2000)
   }, [activeChannelId, sendTypingStart, sendTypingStop])
 
-  const handleSubmit = (e: React.FormEvent): void => {
-    e.preventDefault()
-    if (!content.trim() || !activeChannelId) return
+  const stageFile = (file: File): void => {
+    setStagedFiles((prev) => [...prev, { file, id: `staged-${++stagedIdCounter}` }])
+  }
 
-    sendMessage(activeChannelId, content.trim())
-    setContent('')
+  const removeStagedFile = (id: string): void => {
+    setStagedFiles((prev) => prev.filter((entry) => entry.id !== id))
+  }
+
+  const uploadAndSendFile = async (file: File, text: string | undefined): Promise<boolean> => {
+    if (!activeChannelId) return false
+    if (!canUseE2EE) {
+      useMessageStore.setState({
+        encryptionError: 'Approve this device to send encrypted messages.'
+      })
+      return false
+    }
+
+    const fileData = await file.arrayBuffer()
+    const encrypted = await encryptFile(fileData)
+    const blob = new Blob([encrypted.ciphertext])
+    const formData = new FormData()
+    formData.append('file', blob, file.name)
+    formData.append('encrypted', 'true')
+
+    const res = await apiUpload('/api/v1/attachments', formData)
+    if (!res.ok) return false
+
+    const data = await res.json()
+    const attachmentId = data.attachment.id
+
+    const envelope = encodePayload({
+      v: 1,
+      type: 'file',
+      text: text || undefined,
+      file: {
+        id: attachmentId,
+        name: file.name,
+        content_type: file.type || 'application/octet-stream',
+        size: file.size,
+        key: encrypted.key,
+        iv: encrypted.iv
+      }
+    })
+
+    const topic = `chat:channel:${activeChannelId}`
+    const crypto = useCryptoStore.getState()
+    const replyTo = useMessageStore.getState().replyingTo
+    const parentId = replyTo?.id || undefined
+    if (!crypto.hasGroup(activeChannelId)) {
+      const ready = await ensureChannelGroupReady(activeChannelId)
+      if (!ready) {
+        useMessageStore.setState({
+          encryptionError: 'File could not be encrypted. Please try again.'
+        })
+        return false
+      }
+    }
+
+    if (crypto.hasGroup(activeChannelId)) {
+      const enc = await crypto.encryptForChannel(activeChannelId, envelope)
+      if (enc) {
+        cacheSentPlaintext(enc.ciphertext, envelope)
+        pushToChannel(topic, 'new_message', {
+          ciphertext: enc.ciphertext,
+          mls_epoch: enc.epoch,
+          attachment_ids: [attachmentId],
+          ...(parentId && { parent_message_id: parentId })
+        })
+        return true
+      }
+    }
+
+    useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
+    return false
+  }
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault()
+    if (!activeChannelId) return
+
+    const hasText = content.trim().length > 0
+    const hasFiles = stagedFiles.length > 0
+
+    if (!hasText && !hasFiles) return
+
+    // If there are staged files, upload them
+    if (hasFiles) {
+      setUploading(true)
+      try {
+        // First file gets the text caption, rest are sent without text
+        for (let i = 0; i < stagedFiles.length; i++) {
+          const text = i === 0 ? content.trim() : undefined
+          const ok = await uploadAndSendFile(stagedFiles[i].file, text)
+          if (!ok) {
+            setUploading(false)
+            return
+          }
+        }
+        setStagedFiles([])
+        setContent('')
+        useMessageStore.getState().setReplyingTo(null)
+      } catch {
+        // ignore
+      } finally {
+        setUploading(false)
+      }
+    } else {
+      // Text-only message
+      sendMessage(activeChannelId, content.trim())
+      setContent('')
+    }
+
     setMentionQuery(null)
 
     if (typingTimeoutRef.current) {
@@ -81,7 +191,7 @@ export default function MessageInput(): React.JSX.Element {
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit(e)
+      void handleSubmit(e)
     }
     if (e.key === 'Escape') {
       if (mentionQuery !== null) {
@@ -118,91 +228,17 @@ export default function MessageInput(): React.JSX.Element {
     textareaRef.current?.focus()
   }
 
-  const uploadFile = async (file: File): Promise<void> => {
-    if (!activeChannelId) return
-    if (!canUseE2EE) {
-      useMessageStore.setState({
-        encryptionError: 'Approve this device to send encrypted messages.'
-      })
-      return
-    }
-
-    setUploading(true)
-    try {
-      const fileData = await file.arrayBuffer()
-      const encrypted = await encryptFile(fileData)
-      const blob = new Blob([encrypted.ciphertext])
-      const formData = new FormData()
-      formData.append('file', blob, file.name)
-      formData.append('encrypted', 'true')
-
-      const res = await apiUpload('/api/v1/attachments', formData)
-      if (!res.ok) return
-
-      const data = await res.json()
-      const attachmentId = data.attachment.id
-
-      const envelope = encodePayload({
-        v: 1,
-        type: 'file',
-        text: content.trim() || undefined,
-        file: {
-          id: attachmentId,
-          name: file.name,
-          content_type: file.type || 'application/octet-stream',
-          size: file.size,
-          key: encrypted.key,
-          iv: encrypted.iv
-        }
-      })
-
-      const topic = `chat:channel:${activeChannelId}`
-      const crypto = useCryptoStore.getState()
-      const replyTo = useMessageStore.getState().replyingTo
-      const parentId = replyTo?.id || undefined
-      if (!crypto.hasGroup(activeChannelId)) {
-        const ready = await ensureChannelGroupReady(activeChannelId)
-        if (!ready) {
-          useMessageStore.setState({
-            encryptionError: 'File could not be encrypted. Please try again.'
-          })
-          return
-        }
-      }
-
-      if (crypto.hasGroup(activeChannelId)) {
-        const enc = await crypto.encryptForChannel(activeChannelId, envelope)
-        if (enc) {
-          cacheSentPlaintext(enc.ciphertext, envelope)
-          pushToChannel(topic, 'new_message', {
-            ciphertext: enc.ciphertext,
-            mls_epoch: enc.epoch,
-            attachment_ids: [attachmentId],
-            ...(parentId && { parent_message_id: parentId })
-          })
-          setContent('')
-          useMessageStore.getState().setReplyingTo(null)
-          return
-        }
-      }
-
-      useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
-    } catch {
-      // ignore
-    } finally {
-      setUploading(false)
-    }
-  }
-
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const file = e.target.files?.[0]
-    if (!file) return
-
-    await uploadFile(file)
+    if (file) {
+      stageFile(file)
+    }
 
     if (fileInputRef.current) {
       fileInputRef.current.value = ''
     }
+
+    textareaRef.current?.focus()
   }
 
   const handleDragEnter = (event: React.DragEvent<HTMLFormElement>): void => {
@@ -221,39 +257,37 @@ export default function MessageInput(): React.JSX.Element {
     }
   }
 
-  const handleDrop = async (event: React.DragEvent<HTMLFormElement>): Promise<void> => {
+  const handleDrop = (event: React.DragEvent<HTMLFormElement>): void => {
     event.preventDefault()
     event.stopPropagation()
     dragDepthRef.current = 0
     setDragActive(false)
 
     const file = event.dataTransfer.files?.[0]
-    if (!file || uploading) {
-      return
+    if (file && !uploading) {
+      stageFile(file)
     }
-
-    await uploadFile(file)
   }
+
+  const canSend = content.trim().length > 0 || stagedFiles.length > 0
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={(e) => { void handleSubmit(e) }}
       onDragEnter={handleDragEnter}
       onDragOver={(event) => {
         event.preventDefault()
         event.stopPropagation()
       }}
       onDragLeave={handleDragLeave}
-      onDrop={(event) => {
-        void handleDrop(event)
-      }}
+      onDrop={handleDrop}
       className={`vesper-composer-form${dragActive ? ' vesper-composer-form-dragging' : ''}`}
     >
       {dragActive && (
         <div className="vesper-composer-drop-overlay" aria-hidden="true">
           <div className="vesper-composer-drop-card">
             <Paperclip className="w-5 h-5" />
-            <span>Drop a file to send it to this channel</span>
+            <span>Drop a file to attach it</span>
           </div>
         </div>
       )}
@@ -275,6 +309,8 @@ export default function MessageInput(): React.JSX.Element {
         onClearEncryptionError={() => useMessageStore.setState({ encryptionError: null })}
         replyingTo={replyingTo}
         onCancelReply={() => setReplyingTo(null)}
+        stagedFiles={stagedFiles}
+        onRemoveStagedFile={removeStagedFile}
       >
         <div className="vesper-composer-controls">
           <button
@@ -328,7 +364,7 @@ export default function MessageInput(): React.JSX.Element {
           <button
             data-testid="send-button"
             type="submit"
-            disabled={!content.trim()}
+            disabled={!canSend || uploading}
             className="vesper-composer-send"
           >
             <SendHorizonal className="w-5 h-5" />

--- a/client/src/renderer/src/components/chat/MessageItem.tsx
+++ b/client/src/renderer/src/components/chat/MessageItem.tsx
@@ -5,6 +5,8 @@ import { useMessageStore, parseMessageContent } from '../../stores/messageStore'
 import { useAuthStore } from '../../stores/authStore'
 import { usePresenceStore, type PresenceStatus } from '../../stores/presenceStore'
 import { useServerStore } from '../../stores/serverStore'
+import { useDmStore } from '../../stores/dmStore'
+import { useUIStore } from '../../stores/uiStore'
 import Avatar from '../ui/Avatar'
 import MarkdownContent from './MarkdownContent'
 import EmojiPicker from './EmojiPicker'
@@ -15,6 +17,7 @@ import { useContextMenu } from '../../hooks/useContextMenu'
 import MessageActions from './message/MessageActions'
 import MessageReplyPreview from './message/MessageReplyPreview'
 import MessageReactionBar from './message/MessageReactionBar'
+import ProfilePopout from '../profile/ProfilePopout'
 import { formatCustomEmojiToken, type CustomEmoji } from '../../utils/emoji'
 
 const STATUS_COLORS: Record<PresenceStatus, string> = {
@@ -181,6 +184,12 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
   const setEditingMessage = useMessageStore((s) => s.setEditingMessage)
   const editMessage = useMessageStore((s) => s.editMessage)
   const deleteMessage = useMessageStore((s) => s.deleteMessage)
+  const createConversation = useDmStore((s) => s.createConversation)
+  const setActiveServer = useServerStore((s) => s.setActiveServer)
+  const openSettingsModal = useUIStore((s) => s.openSettingsModal)
+
+  const [profileAnchor, setProfileAnchor] = useState<DOMRect | null>(null)
+  const [showProfile, setShowProfile] = useState(false)
 
   const targetId = message.channel_id || message.conversation_id || ''
   const topic = message.channel_id
@@ -273,6 +282,16 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
     setShowEmojiPicker(false)
   }
 
+  const handleOpenProfile = (event: React.MouseEvent): void => {
+    setProfileAnchor((event.currentTarget as HTMLElement).getBoundingClientRect())
+    setShowProfile(true)
+  }
+
+  const handleCloseProfile = (): void => {
+    setShowProfile(false)
+    setProfileAnchor(null)
+  }
+
   const getMessageItems = (): ContextMenuItem[] => {
     return [
       {
@@ -357,7 +376,11 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
     >
       <div className="vesper-message-avatar-column">
         {startsGroup ? (
-          <div className="relative w-10 h-10 shrink-0 mt-0.5">
+          <button
+            type="button"
+            className="relative w-10 h-10 shrink-0 mt-0.5 cursor-pointer border-0 bg-transparent p-0"
+            onClick={handleOpenProfile}
+          >
             <Avatar
               userId={message.sender_id || 'unknown'}
               avatarUrl={avatarUrl}
@@ -365,7 +388,7 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
               size="md"
             />
             <div className={`absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border-2 border-bg-primary ${STATUS_COLORS[status]}`} />
-          </div>
+          </button>
         ) : (
           <span className="vesper-message-inline-time">{formatTime(message.inserted_at)}</span>
         )}
@@ -410,7 +433,14 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
 
         {startsGroup && (
           <div className="vesper-message-header">
-            <span data-testid="message-sender" className="vesper-message-author">{displayName}</span>
+            <button
+              type="button"
+              data-testid="message-sender"
+              className="vesper-message-author vesper-message-author-clickable"
+              onClick={handleOpenProfile}
+            >
+              {displayName}
+            </button>
             <span className="vesper-message-time">{formatTime(message.inserted_at)}</span>
           </div>
         )}
@@ -485,6 +515,34 @@ export default function MessageItem({ message, messages, previousMessage }: Prop
           y={msgMenu.menu.y}
           items={getMessageItems()}
           onClose={msgMenu.closeMenu}
+        />
+      )}
+
+      {showProfile && message.sender_id && (
+        <ProfilePopout
+          user={{
+            id: message.sender_id,
+            username: (liveMember?.user?.username || message.sender?.username || 'unknown'),
+            displayName,
+            avatarUrl: avatarUrl ?? null,
+            status,
+            roleLabel: activeServer?.owner_id === message.sender_id
+              ? 'Owner'
+              : liveMember?.role ?? undefined,
+            nickname: liveMember?.nickname,
+            isCurrentUser: isMe
+          }}
+          anchorRect={profileAnchor}
+          onClose={handleCloseProfile}
+          onMessage={isMe ? undefined : async () => {
+            await createConversation([message.sender_id!])
+            setActiveServer(null)
+            handleCloseProfile()
+          }}
+          onOpenSettings={isMe ? () => {
+            handleCloseProfile()
+            openSettingsModal()
+          } : undefined}
         />
       )}
     </div>

--- a/client/src/renderer/src/components/chat/message/ComposerShell.tsx
+++ b/client/src/renderer/src/components/chat/message/ComposerShell.tsx
@@ -1,12 +1,19 @@
 import type { ReactNode } from 'react'
-import { X } from 'lucide-react'
+import { FileIcon, X } from 'lucide-react'
 import type { Message } from '../../../stores/messageStore'
+
+export interface StagedFile {
+  file: File
+  id: string
+}
 
 interface Props {
   encryptionError: string | null
   onClearEncryptionError: () => void
   replyingTo: Message | null
   onCancelReply: () => void
+  stagedFiles?: StagedFile[]
+  onRemoveStagedFile?: (id: string) => void
   children: ReactNode
 }
 
@@ -14,13 +21,25 @@ function getReplyAuthor(message: Message): string {
   return message.sender?.display_name || message.sender?.username || 'Unknown'
 }
 
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 export default function ComposerShell({
   encryptionError,
   onClearEncryptionError,
   replyingTo,
   onCancelReply,
+  stagedFiles,
+  onRemoveStagedFile,
   children
 }: Props): React.JSX.Element {
+  const hasStaged = stagedFiles && stagedFiles.length > 0
+  const hasReply = !!replyingTo
+  const hasTopContent = hasStaged || hasReply
+
   return (
     <div className="vesper-composer-wrap">
       {encryptionError && (
@@ -36,8 +55,32 @@ export default function ComposerShell({
         </div>
       )}
 
-      <div className={replyingTo ? 'vesper-composer vesper-composer-has-reply' : 'vesper-composer'}>
-        {replyingTo && (
+      <div className={hasTopContent ? 'vesper-composer vesper-composer-has-reply' : 'vesper-composer'}>
+        {hasStaged && (
+          <div className="vesper-composer-staged-files">
+            {stagedFiles.map((entry) => (
+              <div key={entry.id} className="vesper-composer-staged-file" data-testid="staged-file">
+                <FileIcon className="w-4 h-4 shrink-0 text-accent" />
+                <span className="vesper-composer-staged-name" title={entry.file.name}>
+                  {entry.file.name}
+                </span>
+                <span className="vesper-composer-staged-size">
+                  {formatFileSize(entry.file.size)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onRemoveStagedFile?.(entry.id)}
+                  className="vesper-composer-staged-remove"
+                  aria-label={`Remove ${entry.file.name}`}
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasReply && (
           <div className="vesper-composer-reply">
             <div className="vesper-composer-reply-copy">
               <span className="vesper-composer-reply-label">Replying to</span>

--- a/client/src/renderer/src/components/dm/DmMessageInput.tsx
+++ b/client/src/renderer/src/components/dm/DmMessageInput.tsx
@@ -10,12 +10,16 @@ import { pushToChannel } from '../../api/socket'
 import { useAuthStore } from '../../stores/authStore'
 import EmojiPicker from '../chat/EmojiPicker'
 import ComposerShell from '../chat/message/ComposerShell'
+import type { StagedFile } from '../chat/message/ComposerShell'
 import { formatCustomEmojiToken } from '../../utils/emoji'
+
+let stagedIdCounter = 0
 
 export default function DmMessageInput(): React.JSX.Element {
   const [content, setContent] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [uploading, setUploading] = useState(false)
+  const [stagedFiles, setStagedFiles] = useState<StagedFile[]>([])
   const conversationId = useDmStore((s) => s.selectedConversationId)
   const sendDmMessage = useMessageStore((s) => s.sendDmMessage)
   const sendDmTypingStart = useMessageStore((s) => s.sendDmTypingStart)
@@ -49,12 +53,168 @@ export default function DmMessageInput(): React.JSX.Element {
     }, 2000)
   }, [conversationId, sendDmTypingStart, sendDmTypingStop])
 
-  const handleSubmit = (e: React.FormEvent): void => {
-    e.preventDefault()
-    if (!content.trim() || !conversationId) return
+  const stageFile = (file: File): void => {
+    setStagedFiles((prev) => [...prev, { file, id: `staged-dm-${++stagedIdCounter}` }])
+  }
 
-    sendDmMessage(conversationId, content.trim())
-    setContent('')
+  const removeStagedFile = (id: string): void => {
+    setStagedFiles((prev) => prev.filter((entry) => entry.id !== id))
+  }
+
+  const ensureDmGroup = async (topic: string): Promise<boolean> => {
+    const crypto = useCryptoStore.getState()
+    if (crypto.hasGroup(conversationId!)) return true
+
+    await crypto.createGroup(conversationId!)
+    if (!crypto.hasGroup(conversationId!)) return false
+
+    const conversation = useDmStore
+      .getState()
+      .conversations.find((entry) => entry.id === conversationId)
+    const myId = useAuthStore.getState().user?.id
+
+    if (conversation && myId) {
+      for (const participant of conversation.participants) {
+        if (participant.user_id === myId) continue
+        const result = await crypto.handleJoinRequest(
+          conversationId!,
+          participant.user_id,
+          participant.user.username
+        )
+        if (!result) continue
+
+        pushToChannel(topic, 'mls_commit', {
+          commit_data: result.commitBytes
+        })
+
+        if (result.welcomeBytes) {
+          pushToChannel(topic, 'mls_welcome', {
+            recipient_id: participant.user_id,
+            welcome_data: result.welcomeBytes
+          })
+        }
+      }
+    }
+
+    return crypto.hasGroup(conversationId!)
+  }
+
+  const uploadAndSendFile = async (file: File, text: string | undefined): Promise<boolean> => {
+    if (!conversationId) return false
+    if (!canUseE2EE) {
+      useMessageStore.setState({
+        encryptionError: 'Approve this device to send encrypted messages.'
+      })
+      return false
+    }
+
+    const fileData = await file.arrayBuffer()
+    const encrypted = await encryptFile(fileData)
+    const blob = new Blob([encrypted.ciphertext])
+    const formData = new FormData()
+    formData.append('file', blob, file.name)
+    formData.append('encrypted', 'true')
+
+    const res = await apiUpload('/api/v1/attachments', formData)
+    if (!res.ok) return false
+
+    const data = await res.json()
+    const attachmentId = data.attachment.id
+
+    const envelope = encodePayload({
+      v: 1,
+      type: 'file',
+      text: text || null,
+      file: {
+        id: attachmentId,
+        name: file.name,
+        content_type: file.type || 'application/octet-stream',
+        size: file.size,
+        key: encrypted.key,
+        iv: encrypted.iv
+      }
+    })
+
+    const topic = `dm:${conversationId}`
+    const crypto = useCryptoStore.getState()
+    const replyTo = useMessageStore.getState().replyingTo
+    const parentId = replyTo?.id || undefined
+
+    // Try encrypting with existing group
+    const enc = crypto.hasGroup(conversationId)
+      ? await crypto.encryptForChannel(conversationId, envelope)
+      : null
+
+    if (enc) {
+      cacheSentPlaintext(enc.ciphertext, envelope)
+      pushToChannel(topic, 'new_message', {
+        ciphertext: enc.ciphertext,
+        mls_epoch: enc.epoch,
+        attachment_ids: [attachmentId],
+        ...(parentId && { parent_message_id: parentId })
+      })
+      return true
+    }
+
+    // Reset and create fresh group
+    if (crypto.hasGroup(conversationId)) {
+      await crypto.resetGroup(conversationId)
+    }
+
+    const groupReady = await ensureDmGroup(topic)
+    if (!groupReady) {
+      useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
+      return false
+    }
+
+    const freshEncrypted = await crypto.encryptForChannel(conversationId, envelope)
+    if (freshEncrypted) {
+      cacheSentPlaintext(freshEncrypted.ciphertext, envelope)
+      pushToChannel(topic, 'new_message', {
+        ciphertext: freshEncrypted.ciphertext,
+        mls_epoch: freshEncrypted.epoch,
+        attachment_ids: [attachmentId],
+        ...(parentId && { parent_message_id: parentId })
+      })
+      return true
+    }
+
+    useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
+    return false
+  }
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault()
+    if (!conversationId) return
+
+    const hasText = content.trim().length > 0
+    const hasFiles = stagedFiles.length > 0
+
+    if (!hasText && !hasFiles) return
+
+    if (hasFiles) {
+      setUploading(true)
+      try {
+        for (let i = 0; i < stagedFiles.length; i++) {
+          const text = i === 0 ? content.trim() : undefined
+          const ok = await uploadAndSendFile(stagedFiles[i].file, text)
+          if (!ok) {
+            setUploading(false)
+            return
+          }
+        }
+        setStagedFiles([])
+        setContent('')
+        useMessageStore.getState().setReplyingTo(null)
+      } catch {
+        // ignore
+      } finally {
+        setUploading(false)
+      }
+    } else {
+      sendDmMessage(conversationId, content.trim())
+      setContent('')
+    }
 
     if (typingTimeoutRef.current) {
       clearTimeout(typingTimeoutRef.current)
@@ -68,134 +228,18 @@ export default function DmMessageInput(): React.JSX.Element {
   const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit(e)
+      void handleSubmit(e)
     }
     if (e.key === 'Escape' && replyingTo) {
       setReplyingTo(null)
     }
   }
 
-  const uploadFile = async (file: File): Promise<void> => {
-    if (!file || !conversationId) return
-    if (!canUseE2EE) {
-      useMessageStore.setState({
-        encryptionError: 'Approve this device to send encrypted messages.'
-      })
-      return
-    }
-
-    setUploading(true)
-    try {
-      const fileData = await file.arrayBuffer()
-      const encrypted = await encryptFile(fileData)
-      const blob = new Blob([encrypted.ciphertext])
-      const formData = new FormData()
-      formData.append('file', blob, file.name)
-      formData.append('encrypted', 'true')
-
-      const res = await apiUpload('/api/v1/attachments', formData)
-      if (!res.ok) return
-
-      const data = await res.json()
-      const attachmentId = data.attachment.id
-
-      const envelope = encodePayload({
-        v: 1,
-        type: 'file',
-        text: content.trim() || null,
-        file: {
-          id: attachmentId,
-          name: file.name,
-          content_type: file.type || 'application/octet-stream',
-          size: file.size,
-          key: encrypted.key,
-          iv: encrypted.iv
-        }
-      })
-
-      const topic = `dm:${conversationId}`
-      const crypto = useCryptoStore.getState()
-      const replyTo = useMessageStore.getState().replyingTo
-      const parentId = replyTo?.id || undefined
-      const enc = crypto.hasGroup(conversationId)
-        ? await crypto.encryptForChannel(conversationId, envelope)
-        : null
-
-      if (enc) {
-        cacheSentPlaintext(enc.ciphertext, envelope)
-        pushToChannel(topic, 'new_message', {
-          ciphertext: enc.ciphertext,
-          mls_epoch: enc.epoch,
-          attachment_ids: [attachmentId],
-          ...(parentId && { parent_message_id: parentId })
-        })
-        setContent('')
-        useMessageStore.getState().setReplyingTo(null)
-        return
-      }
-
-      if (crypto.hasGroup(conversationId)) {
-        await crypto.resetGroup(conversationId)
-      }
-
-      await crypto.createGroup(conversationId)
-      if (crypto.hasGroup(conversationId)) {
-        const conversation = useDmStore
-          .getState()
-          .conversations.find((entry) => entry.id === conversationId)
-        const myId = useAuthStore.getState().user?.id
-
-        if (conversation && myId) {
-          for (const participant of conversation.participants) {
-            if (participant.user_id === myId) continue
-            const result = await crypto.handleJoinRequest(
-              conversationId,
-              participant.user_id,
-              participant.user.username
-            )
-            if (!result) continue
-
-            pushToChannel(topic, 'mls_commit', {
-              commit_data: result.commitBytes
-            })
-
-            if (result.welcomeBytes) {
-              pushToChannel(topic, 'mls_welcome', {
-                recipient_id: participant.user_id,
-                welcome_data: result.welcomeBytes
-              })
-            }
-          }
-        }
-
-        const freshEncrypted = await crypto.encryptForChannel(conversationId, envelope)
-        if (freshEncrypted) {
-          cacheSentPlaintext(freshEncrypted.ciphertext, envelope)
-          pushToChannel(topic, 'new_message', {
-            ciphertext: freshEncrypted.ciphertext,
-            mls_epoch: freshEncrypted.epoch,
-            attachment_ids: [attachmentId],
-            ...(parentId && { parent_message_id: parentId })
-          })
-          setContent('')
-          useMessageStore.getState().setReplyingTo(null)
-          return
-        }
-      }
-
-      useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
-    } catch {
-      // ignore
-    } finally {
-      setUploading(false)
-    }
-  }
-
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const file = e.target.files?.[0]
-    if (!file) return
-
-    await uploadFile(file)
+    if (file) {
+      stageFile(file)
+    }
 
     if (fileInputRef.current) {
       fileInputRef.current.value = ''
@@ -218,39 +262,37 @@ export default function DmMessageInput(): React.JSX.Element {
     }
   }
 
-  const handleDrop = async (event: React.DragEvent<HTMLFormElement>): Promise<void> => {
+  const handleDrop = (event: React.DragEvent<HTMLFormElement>): void => {
     event.preventDefault()
     event.stopPropagation()
     dragDepthRef.current = 0
     setDragActive(false)
 
     const file = event.dataTransfer.files?.[0]
-    if (!file || uploading) {
-      return
+    if (file && !uploading) {
+      stageFile(file)
     }
-
-    await uploadFile(file)
   }
+
+  const canSend = content.trim().length > 0 || stagedFiles.length > 0
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={(e) => { void handleSubmit(e) }}
       onDragEnter={handleDragEnter}
       onDragOver={(event) => {
         event.preventDefault()
         event.stopPropagation()
       }}
       onDragLeave={handleDragLeave}
-      onDrop={(event) => {
-        void handleDrop(event)
-      }}
+      onDrop={handleDrop}
       className={`vesper-composer-form${dragActive ? ' vesper-composer-form-dragging' : ''}`}
     >
       {dragActive && (
         <div className="vesper-composer-drop-overlay" aria-hidden="true">
           <div className="vesper-composer-drop-card">
             <Paperclip className="w-5 h-5" />
-            <span>Drop a file to send it in this DM</span>
+            <span>Drop a file to attach it</span>
           </div>
         </div>
       )}
@@ -259,6 +301,8 @@ export default function DmMessageInput(): React.JSX.Element {
         onClearEncryptionError={() => useMessageStore.setState({ encryptionError: null })}
         replyingTo={replyingTo}
         onCancelReply={() => setReplyingTo(null)}
+        stagedFiles={stagedFiles}
+        onRemoveStagedFile={removeStagedFile}
       >
         <div className="vesper-composer-controls">
           <button
@@ -313,7 +357,7 @@ export default function DmMessageInput(): React.JSX.Element {
           />
           <button
             type="submit"
-            disabled={!content.trim()}
+            disabled={!canSend || uploading}
             className="vesper-composer-send"
           >
             <SendHorizonal className="w-5 h-5" />

--- a/client/src/renderer/src/components/layout/Sidebar.tsx
+++ b/client/src/renderer/src/components/layout/Sidebar.tsx
@@ -861,11 +861,42 @@ function InviteCodeButton({ serverId }: { serverId: string }): React.JSX.Element
   const [copied, setCopied] = useState(false)
   const [loading, setLoading] = useState(false)
   const [denied, setDenied] = useState(false)
+  const [countdown, setCountdown] = useState(0)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const AUTO_HIDE_SECONDS = 15
+
+  const clearTimer = (): void => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  const hideCode = (): void => {
+    setVisible(false)
+    setCode(null)
+    setCountdown(0)
+    clearTimer()
+  }
+
+  const startTimer = (): void => {
+    clearTimer()
+    setCountdown(AUTO_HIDE_SECONDS)
+    timerRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          hideCode()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }
 
   const fetchAndShow = async (): Promise<void> => {
     if (visible) {
-      setVisible(false)
-      setCode(null)
+      hideCode()
       return
     }
 
@@ -876,6 +907,7 @@ function InviteCodeButton({ serverId }: { serverId: string }): React.JSX.Element
         const data = await res.json()
         setCode(data.invite_code)
         setVisible(true)
+        startTimer()
       } else if (res.status === 403) {
         setDenied(true)
       }
@@ -894,6 +926,8 @@ function InviteCodeButton({ serverId }: { serverId: string }): React.JSX.Element
     navigator.clipboard.writeText(code)
     setCopied(true)
     window.setTimeout(() => setCopied(false), 2000)
+    // Reset timer on copy since the user is interacting
+    startTimer()
   }
 
   useEffect(() => {
@@ -901,7 +935,12 @@ function InviteCodeButton({ serverId }: { serverId: string }): React.JSX.Element
     setVisible(false)
     setCopied(false)
     setDenied(false)
+    clearTimer()
   }, [serverId])
+
+  useEffect(() => {
+    return () => clearTimer()
+  }, [])
 
   if (denied) {
     return null
@@ -910,19 +949,29 @@ function InviteCodeButton({ serverId }: { serverId: string }): React.JSX.Element
   return (
     <div className="flex items-center gap-1 shrink-0">
       {visible && code ? (
-        <button
-          type="button"
-          onClick={copyCode}
-          title={copied ? 'Copied!' : 'Copy invite code'}
-          className="flex items-center gap-1 bg-bg-base/50 px-1.5 py-0.5 rounded border border-border hover:border-accent/50 transition-colors max-w-[100px]"
-        >
-          <code className="text-accent-text text-[10px] font-mono truncate">{code}</code>
-          {copied ? (
-            <Check className="w-3 h-3 text-emerald-400 shrink-0" />
-          ) : (
-            <Copy className="w-3 h-3 text-text-faint shrink-0" />
-          )}
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={copyCode}
+            title={copied ? 'Copied!' : 'Copy invite code'}
+            className="flex items-center gap-1 bg-bg-base/50 px-1.5 py-0.5 rounded border border-border hover:border-accent/50 transition-colors max-w-[100px]"
+          >
+            <code className="text-accent-text text-[10px] font-mono truncate">{code}</code>
+            {copied ? (
+              <Check className="w-3 h-3 text-emerald-400 shrink-0" />
+            ) : (
+              <Copy className="w-3 h-3 text-text-faint shrink-0" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={hideCode}
+            title="Dismiss"
+            className="text-text-faintest hover:text-text-muted transition-colors text-[10px] tabular-nums w-5 text-center"
+          >
+            {countdown}s
+          </button>
+        </div>
       ) : null}
       <button
         type="button"

--- a/client/src/renderer/src/index.css
+++ b/client/src/renderer/src/index.css
@@ -519,6 +519,19 @@
   color: var(--color-text-primary);
 }
 
+.vesper-message-author-clickable {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
+
+.vesper-message-author-clickable:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
 .vesper-message-time {
   font-size: 0.72rem;
   color: var(--color-text-faintest);
@@ -2534,6 +2547,59 @@
   background: transparent;
   color: var(--color-text-faint);
   cursor: pointer;
+}
+
+.vesper-composer-staged-files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.65rem 0.75rem 0.4rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+.vesper-composer-staged-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  max-width: 16rem;
+  padding: 0.35rem 0.45rem 0.35rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  border-radius: 0.7rem;
+  background: color-mix(in srgb, var(--color-bg-tertiary) 50%, transparent);
+  font-size: 0.78rem;
+  line-height: 1;
+}
+
+.vesper-composer-staged-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.vesper-composer-staged-size {
+  color: var(--color-text-faint);
+  white-space: nowrap;
+}
+
+.vesper-composer-staged-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.3rem;
+  height: 1.3rem;
+  border: 0;
+  border-radius: 0.4rem;
+  background: transparent;
+  color: var(--color-text-faint);
+  cursor: pointer;
+  transition: background-color 0.14s ease, color 0.14s ease;
+}
+
+.vesper-composer-staged-remove:hover {
+  background: color-mix(in srgb, var(--color-bg-tertiary) 80%, transparent);
+  color: #fca5a5;
 }
 
 .vesper-composer-controls {


### PR DESCRIPTION
Four UI fixes across the chat interface.

### Disappearing messages dropdown z-index

The disappearing messages dropdown in the header was rendering behind message action toolbars. The header's `backdrop-filter` created a stacking context at implicit z-index 0, while the message toolbar slots sat at z-index 10 — so hovering messages behind the open dropdown caused their action buttons to appear on top of it. Fixed by giving `.vesper-chat-header` explicit `position: relative; z-index: 20`.

### Staged file uploads

Previously, selecting or dropping a file immediately uploaded and sent it along with whatever text was currently in the composer. Now files are staged as removable pills above the message input, showing filename and size. Users can continue typing, attach additional files, or remove staged files before sending. On submit the first file carries the text caption; additional files send as separate messages. Both the channel and DM composers share this behavior through `ComposerShell`.

**Before:** File selected → encrypted → uploaded → message sent immediately.
**After:** File selected → staged pill appears → user sends when ready.

### Profile popout from chat messages

Clicking a user's avatar or display name in the message list now opens the `ProfilePopout` card — the same component already used in the member list sidebar. Shows online status, server role, About Me / Details tabs, and contextual action buttons (Edit Profile for yourself, Message for other users). The username gets an accent-colored underline on hover to indicate it's interactive.

### Invite code auto-dismiss

The sidebar invite code button now shows a 15-second countdown timer next to the code. When the timer expires, the code hides automatically. Clicking the countdown dismisses immediately. Copying the code resets the timer so it doesn't vanish mid-interaction. The interval cleans up properly on unmount and server change.

---

### Files changed

| File | What changed |
|---|---|
| `client/src/renderer/src/index.css` | Header z-index fix, clickable author styles, staged file pill styles |
| `client/src/renderer/src/components/chat/message/ComposerShell.tsx` | Added `StagedFile` type export, staged files display with remove buttons |
| `client/src/renderer/src/components/chat/MessageInput.tsx` | File staging instead of immediate upload, send enabled when files staged |
| `client/src/renderer/src/components/dm/DmMessageInput.tsx` | Same staging behavior for DM composer |
| `client/src/renderer/src/components/chat/MessageItem.tsx` | Avatar + username click → ProfilePopout, wired to DM creation + settings |
| `client/src/renderer/src/components/layout/Sidebar.tsx` | Invite code 15s countdown timer with auto-dismiss |

### Testing

- Built and deployed to Docker (`sudo docker compose build web && sudo docker compose up -d web`)
- Verified disappearing messages dropdown renders above message actions
- Verified clicking username in chat opens profile card with correct data
- Verified invite code shows countdown and auto-dismisses at 0
- TypeScript compiles clean (`npx tsc --noEmit`)