### PR TITLE
docs: update README and CONTRIBUTING for nightly pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Git hooks help for local clones, but the real repo-wide gate is GitHub Actions. 
 - **Server Tests** (`.github/workflows/test-server.yml`) — runs `mix test` with a PostgreSQL 17 service container when `server/` files change
 - **Client Checks** (`.github/workflows/test-client.yml`) — runs `npm run check:web` when `client/` files change
 
-Both skip `.md`-only changes and use a gate job pattern so branch protection status checks pass even when the test jobs are skipped (e.g., a server-only change won't block on client checks). Configure branch protection to require the `server-tests` and `client-checks` job names.
+Both skip `.md`-only changes and use a gate job pattern so branch protection status checks pass even when the test jobs are skipped (e.g., a server-only change won't block on client checks). Configure branch protection to require the `server-checks` and `client-checks` job names.
 
 ### Server tests
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ client/                  Electron + React frontend
   docker-server.yml        build & push server Docker image
   docker-web.yml           build & push web client Docker image
   release.yml              build desktop installers
+  nightly.yml              daily nightly release (Docker + desktop)
+.github/CI.md             CI/CD pipeline documentation
 
 doc/
   DESIGN.md              architecture overview


### PR DESCRIPTION
Updates project documentation to reflect the nightly release pipeline and CI job renames from PR #35.

### Changes

- **README.md** — Added `nightly.yml` and `CI.md` to the project structure tree
- **CONTRIBUTING.md** — Fixed stale reference to `server-tests` gate job → `server-checks` to match the rename in #35