### PR TITLE
fix: include SDK in Docker web build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+server/
+client/node_modules/
+client/dist/
+client/dist-web/
+sdk/node_modules/
+sdk/dist/
+**/.env*

--- a/.github/workflows/docker-web.yml
+++ b/.github/workflows/docker-web.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
     paths:
       - "client/**"
+      - "sdk/**"
       - ".github/workflows/docker-web.yml"
 
 concurrency:
@@ -50,7 +51,7 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: ./client
+          context: .
           file: ./client/Dockerfile.web
           push: true
           provenance: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -149,7 +149,7 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: ./client
+          context: .
           file: ./client/Dockerfile.web
           push: true
           provenance: false

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -35,8 +35,8 @@ jobs:
             HEAD=${{ github.sha }}
           fi
 
-          # Any non-markdown files changed under client/?
-          if git diff --name-only "$BASE" "$HEAD" -- 'client/' | grep -qvE '\.md$'; then
+          # Any non-markdown files changed under client/ or sdk/?
+          if git diff --name-only "$BASE" "$HEAD" -- 'client/' 'sdk/' | grep -qvE '\.md$'; then
             echo "client=true" >> "$GITHUB_OUTPUT"
           else
             echo "client=false" >> "$GITHUB_OUTPUT"

--- a/client/Dockerfile.web
+++ b/client/Dockerfile.web
@@ -1,18 +1,19 @@
 # Stage 1: Build the web client
 FROM node:22-alpine AS build
 
-WORKDIR /app
-COPY package.json package-lock.json ./
+WORKDIR /app/client
+COPY client/package.json client/package-lock.json ./
 RUN npm ci --ignore-scripts
 
-COPY . .
+COPY client/ .
+COPY sdk/ /app/sdk/
 RUN npm run build:web
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 
-COPY --from=build /app/dist-web /usr/share/nginx/html
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=build /app/client/dist-web /usr/share/nginx/html
+COPY --from=build /app/client/docker-entrypoint.sh /docker-entrypoint.sh
 
 # SPA fallback — route all paths to index.html
 RUN printf 'server {\n\


### PR DESCRIPTION
## Summary
- Widen Docker web build context from `./client` to `.` (repo root) so the SDK at `../sdk/` is available during the Vite build
- Add root `.dockerignore` to keep the build context lean (excludes `server/`, `.git`, `node_modules/`)
- Add `sdk/**` to `docker-web.yml` path triggers and `test-client.yml` change detection

## Test plan
- [ ] `docker build -f client/Dockerfile.web -t vesper-web-test .` succeeds locally
- [ ] Nightly CI web build passes
- [ ] `docker-web.yml` triggers on SDK-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)