### PR TITLE
fix: symlink node_modules for SDK resolution in Docker web build

### DIFF
--- a/client/Dockerfile.web
+++ b/client/Dockerfile.web
@@ -7,6 +7,7 @@ RUN npm ci --ignore-scripts
 
 COPY client/ .
 COPY sdk/ /app/sdk/
+RUN ln -s /app/client/node_modules /app/sdk/node_modules
 RUN npm run build:web
 
 # Stage 2: Serve with nginx


### PR DESCRIPTION
## Summary
- Symlink `/app/client/node_modules` → `/app/sdk/node_modules` in the Docker build so Vite can resolve SDK dependencies (e.g. `hash-wasm`) when processing `@vesper/sdk` source aliases
- Fixes the nightly CI failure from #46 where the build context was correct but SDK module resolution still failed

## Context
The Vite config aliases `@vesper/sdk` to `../sdk/src/`. When Vite processes those files, Node module resolution starts from `/app/sdk/` and walks up looking for `node_modules`. The client's deps live at `/app/client/node_modules/` which is never reached. The symlink bridges this.

## Test plan
- [x] Local `docker build -f client/Dockerfile.web -t vesper-web-test .` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)