### PR TITLE
fix: detect and recover from MLS group forks

### DIFF
--- a/client/src/renderer/src/stores/messageStore.ts
+++ b/client/src/renderer/src/stores/messageStore.ts
@@ -539,6 +539,7 @@ async function buildMessageFromSdkProcessed(
     reactions: await resolveReactionGroups(targetId, raw.reactions),
     encrypted: processed.encrypted,
     decryptionFailed: processed.decryptionFailed,
+    mls_epoch: (raw.mls_epoch as number | null | undefined) ?? null,
     edited_at: raw.edited_at ?? undefined,
     client_nonce: raw.client_nonce ?? undefined,
     delivery_state: 'sent'
@@ -1255,9 +1256,10 @@ async function processMlsResyncRequest(
     return false
   }
 
-  if (scopeFromTopic(targetId, topic).kind === 'channel' && !(await isLocalChannelOwner(targetId))) {
-    return false
-  }
+  // Any member who holds the group can process resync requests. The SDK-level
+  // handleResyncRequest already restricts this to the first member in the
+  // ratchet tree (the MLS group creator). Gating on server ownership here
+  // caused deadlocks when the server owner was offline or had a forked group.
 
   const isSameUserResync = localUser?.id === requesterId
   const requesterAlreadyJoined =
@@ -2196,6 +2198,42 @@ async function recoverEncryptedScope(
       return
     }
 
+    // Fork detection: we have a group but still can't decrypt messages after
+    // replaying all durable events and requesting resync. Check whether any
+    // failed messages share our current epoch — that means the sender encrypted
+    // with the same epoch number but different tree state (a fork). Reset the
+    // local group and rejoin from the canonical group held by whoever responds
+    // to the join request.
+    const localEpoch = encryptedChat.getGroupEpoch(scope.targetId)
+    const isFork =
+      encryptedChat.hasGroup(scope.targetId) &&
+      localEpoch !== null &&
+      (getState().messagesByChannel[scope.targetId] ?? []).some(
+        (m) =>
+          m.encrypted &&
+          m.decryptionFailed &&
+          typeof m.mls_epoch === 'number' &&
+          m.mls_epoch <= localEpoch
+      )
+
+    if (isFork) {
+      await encryptedChat.resetScope(scope.targetId)
+      await ensureEncryptedScopeMembership(scope).catch(() => {})
+
+      if (encryptedChat.hasGroup(scope.targetId)) {
+        await refreshEncryptedScope(scope, getState).catch(() => {})
+        await processPendingHistoryBundles(
+          scope.targetId,
+          scope.scopeId,
+          useMessageStore.setState
+        ).catch(() => {})
+
+        if (!hasFailedMessagesInScope(scope, getState)) {
+          return
+        }
+      }
+    }
+
     // Recovery exhausted — mark remaining failed messages as permanently unavailable
     // so the UI doesn't keep showing "syncing" forever
     markFailedMessagesUnavailable(scope, getState)
@@ -2414,6 +2452,7 @@ export interface Message {
   reactions?: ReactionGroup[]
   encrypted?: boolean
   decryptionFailed?: boolean
+  mls_epoch?: number | null
   edited_at?: string
   client_nonce?: string
   delivery_state?: 'sending' | 'sent' | 'failed'
@@ -5043,6 +5082,7 @@ async function processIncomingMessage(
       reactions: await resolveReactionGroups(targetId, msg.reactions as RawReaction[] | undefined),
       encrypted: true,
       decryptionFailed: !plaintext,
+      mls_epoch: mlsEpoch,
       edited_at: msg.edited_at ?? undefined,
       client_nonce: msg.client_nonce ?? undefined,
       delivery_state: 'sent'
@@ -5429,9 +5469,10 @@ async function handleMlsJoinRequest(
   const encryptedChat = getRendererEncryptedChat()
 
   if (!encryptedChat.hasGroup(targetId)) return
-  if (scopeFromTopic(targetId, topic).kind === 'channel' && !(await isLocalChannelOwner(targetId))) {
-    return
-  }
+  // Any member who holds the group can process join requests. The SDK-level
+  // handler restricts this to the first member in the ratchet tree. Gating on
+  // server ownership caused deadlocks during fork recovery when the owner had
+  // reset their group state.
   if (inFlightJoinRequests.has(joinRequestKey)) return
 
   const lastHandledAt = recentHandledJoinRequests.get(joinRequestKey) ?? 0

--- a/sdk/src/client/encryptedChat.ts
+++ b/sdk/src/client/encryptedChat.ts
@@ -2140,7 +2140,7 @@ export class VesperEncryptedChat {
     }
   }
 
-  private getGroupEpoch(scopeId: string): number | null {
+  getGroupEpoch(scopeId: string): number | null {
     const state = this.groupStates.get(scopeId)
     if (!state) {
       return null


### PR DESCRIPTION
## Summary

Fixes an unrecoverable MLS group fork that caused all messages from one party to show as "Encrypted message is syncing..." permanently.

## Root Cause Analysis

### The Problem

Two clients in the same channel ended up with **diverged MLS group states** — both at epoch 4 but with different ratchet trees. This is a "fork": ciphertext encrypted by one side cannot be decrypted by the other, even though the epoch numbers match.

Production evidence from IndexedDB analysis:
- **PP's client**: epoch 4, sync seq 5 (all events replayed), own messages decrypt fine (sent-message cache)
- **Neon's client**: epoch 4, 7 failed messages — all from neon in channel `63ca4697`, all at epoch 4
- Both sides had pending `mls_resync_request` events that were never processed

### Three Contributing Failures

**1. Owner-only gate on resync handlers (deadlock)**

`processMlsResyncRequest` and `handleMlsJoinRequest` in `messageStore.ts` were gated on `isLocalChannelOwner()`, which checks `server.owner_id`. The server owner is neon. PP could *never* process neon's resync request, and neon's handler either failed or never fired. This created a deadlock where neither side could recover.

The SDK-level `handleResyncRequest` already restricts processing to the first member in the MLS ratchet tree (the group creator), making the server-ownership check redundant and harmful.

**2. No fork-aware recovery path**

`recoverEncryptedScope` tried history replay and resync in two rounds, but had no concept of a fork. When both sides are at the same epoch, the resync request looks unnecessary from the receiver's perspective. After two failed rounds, the pipeline gave up and marked messages as permanently unavailable.

**3. No epoch data on messages for comparison**

The `Message` interface lacked `mls_epoch`, so the recovery pipeline had no way to compare a failed message's epoch against the local group epoch. Without this data, fork detection was impossible.

## Changes

### 1. Remove owner-only gate from resync handlers
- `processMlsResyncRequest`: removed `isLocalChannelOwner` check
- `handleMlsJoinRequest`: removed `isLocalChannelOwner` check
- The SDK handler's ratchet-tree-member check is sufficient and doesn't have the same deadlock problem

### 2. Add fork detection to `recoverEncryptedScope`
After normal recovery (history replay + resync) fails, the pipeline now checks: do any decrypt-failed messages have an `mls_epoch` <= the local group epoch? If yes, this is a fork — the local group has advanced past (or matches) the epoch that produced the ciphertext, but can't decrypt it.

On fork detection:
1. Reset the local MLS group state
2. Rejoin the group fresh via `ensureEncryptedScopeMembership`
3. Retry history processing
4. Only mark messages unavailable if recovery still fails

### 3. Add `mls_epoch` to `Message` interface
- Added `mls_epoch?: number | null` to the `Message` type
- Populated from both `buildMessageFromSdkProcessed` and `processIncomingMessage`
- Made `EncryptedChat.getGroupEpoch` public so the store can read the local epoch for comparison

## Files Changed

| File | Change |
|------|--------|
| `client/src/renderer/src/stores/messageStore.ts` | Remove owner gates, add fork detection, add `mls_epoch` to Message |
| `sdk/src/client/encryptedChat.ts` | Make `getGroupEpoch` public |

## Test Plan

- [x] TypeScript typecheck passes
- [x] Production web build succeeds (`npm run check:web`)
- [ ] Deploy and verify neon's messages become readable after the fork recovery triggers
- [ ] Verify resync still works when the actual MLS group creator is online


🤖 Generated with [Claude Code](https://claude.com/claude-code)