### PR TITLE
fix: remove SDK owner gate and handle rejoin in MLS join handler

### DIFF
--- a/client/src/renderer/src/stores/messageStore.ts
+++ b/client/src/renderer/src/stores/messageStore.ts
@@ -1819,6 +1819,14 @@ async function bootstrapDmGroupIfLeader(
       continue
     }
 
+    if (result.removeCommitBytes) {
+      pushToChannel(topic, 'mls_remove', {
+        removed_user_id: participant.user_id,
+        removed_device_id: preferredDeviceId,
+        commit_data: result.removeCommitBytes
+      })
+    }
+
     pushToChannel(topic, 'mls_commit', {
       commit_data: result.commitBytes
     })
@@ -2198,25 +2206,13 @@ async function recoverEncryptedScope(
       return
     }
 
-    // Fork detection: we have a group but still can't decrypt messages after
-    // replaying all durable events and requesting resync. Check whether any
-    // failed messages share our current epoch — that means the sender encrypted
-    // with the same epoch number but different tree state (a fork). Reset the
-    // local group and rejoin from the canonical group held by whoever responds
-    // to the join request.
-    const localEpoch = encryptedChat.getGroupEpoch(scope.targetId)
-    const isFork =
-      encryptedChat.hasGroup(scope.targetId) &&
-      localEpoch !== null &&
-      (getState().messagesByChannel[scope.targetId] ?? []).some(
-        (m) =>
-          m.encrypted &&
-          m.decryptionFailed &&
-          typeof m.mls_epoch === 'number' &&
-          m.mls_epoch <= localEpoch
-      )
-
-    if (isFork) {
+    // Last-resort fork recovery: we have a local group but still can't decrypt
+    // messages after replaying all durable MLS events AND requesting a resync.
+    // The most likely cause is a group fork — both sides at the same epoch but
+    // with different ratchet tree states. Reset the local group entirely and
+    // rejoin from scratch so we pick up the canonical group from whoever
+    // responds to the join request.
+    if (encryptedChat.hasGroup(scope.targetId) && hasFailedMessagesInScope(scope, getState)) {
       await encryptedChat.resetScope(scope.targetId)
       await ensureEncryptedScopeMembership(scope).catch(() => {})
 
@@ -5493,6 +5489,13 @@ async function handleMlsJoinRequest(
       )
 
       if (result) {
+        if (result.removeCommitBytes) {
+          pushToChannel(topic, 'mls_remove', {
+            removed_user_id: userId,
+            ...(deviceId ? { removed_device_id: deviceId } : {}),
+            commit_data: result.removeCommitBytes
+          })
+        }
         pushToChannel(topic, 'mls_commit', { commit_data: result.commitBytes })
         if (result.welcomeBytes) {
           pushToChannel(topic, 'mls_welcome', {

--- a/sdk/src/client/encryptedChat.ts
+++ b/sdk/src/client/encryptedChat.ts
@@ -723,6 +723,7 @@ export class VesperEncryptedChat {
     userId: string,
     deviceId: string | null = null
   ): Promise<{
+    removeCommitBytes: string | null
     commitBytes: string
     welcomeBytes: string | null
     keyPackageRef: string
@@ -1103,13 +1104,33 @@ export class VesperEncryptedChat {
       return
     }
 
-    if (scope.kind === 'channel' && !(await this.isChannelOwner(scope.id, localUserId))) {
-      return
+    // Only the first member in the ratchet tree handles join requests to avoid
+    // concurrent epoch commits from multiple members. This replaces an earlier
+    // server-ownership gate that caused deadlocks during fork recovery.
+    if (scope.kind === 'channel') {
+      const state = this.groupStates.get(scope.id)
+      if (state) {
+        const memberIdentities = getGroupMemberIdentities(state)
+        if (
+          memberIdentities[0] !== localUserId &&
+          memberIdentities[0] !== (this.client.getAuthSession()?.user?.username ?? null)
+        ) {
+          return
+        }
+      }
     }
 
     const response = await this.handleJoinRequest(scope.id, requesterId, requesterDeviceId)
     if (!response) {
       return
+    }
+
+    if (response.removeCommitBytes) {
+      await this.client.pushScopeEvent(scope.kind, scope.id, 'mls_remove', {
+        removed_user_id: requesterId,
+        ...(requesterDeviceId ? { removed_device_id: requesterDeviceId } : {}),
+        commit_data: response.removeCommitBytes
+      })
     }
 
     await this.client.pushScopeEvent(scope.kind, scope.id, 'mls_commit', {
@@ -1435,6 +1456,7 @@ export class VesperEncryptedChat {
     userId: string,
     deviceId: string | null
   ): Promise<{
+    removeCommitBytes: string | null
     commitBytes: string
     welcomeBytes: string | null
     keyPackageRef: string
@@ -1466,18 +1488,33 @@ export class VesperEncryptedChat {
         ? new TextDecoder().decode(credential.identity)
         : null
 
+    let workingState = this.cloneGroupState(state)
+    let removeCommitBytes: string | null = null
+
+    // If the requester is already a member, they probably reset their local
+    // MLS state and are trying to rejoin. Remove the stale leaf first so the
+    // add below succeeds (same approach as handleResyncRequest).
+    if (requestedIdentity) {
+      const existingLeafIndex = findExactMemberLeafIndex(workingState, requestedIdentity)
+      if (existingLeafIndex !== null) {
+        const removed = await removeMemberFromGroup(workingState, existingLeafIndex)
+        workingState = removed.newState
+        removeCommitBytes = uint8ToBase64(removed.commitBytes)
+      }
+    }
+
     if (
       requestedIdentity &&
-      (getGroupLeafIdentities(state).includes(requestedIdentity) ||
-        groupHasMember(state, requestedIdentity))
+      findExactMemberLeafIndex(workingState, requestedIdentity) !== null
     ) {
       return null
     }
 
-    const result = await addMemberToGroup(this.cloneGroupState(state), memberKeyPackage)
+    const result = await addMemberToGroup(workingState, memberKeyPackage)
     await this.setGroupState(scopeId, result.newState)
 
     return {
+      removeCommitBytes,
       commitBytes: uint8ToBase64(result.commitBytes),
       welcomeBytes: result.welcomeBytes ? uint8ToBase64(result.welcomeBytes) : null,
       keyPackageRef: uint8ToBase64(keyPackageBytes)


### PR DESCRIPTION
## Summary

Fixes the actual blocking gates that prevented MLS group fork recovery. PR #48 removed owner gates from the message store layer, but the real gates lived in the SDK — this is why the fix didn't work.

## What was wrong with PR #48

- `handleMlsJoinRequest` in the message store (where I removed the owner gate) is **dead code** — never called
- The actual join request handler is `encryptedChat.handleJoinRequestEvent` in the SDK, which had its own `isChannelOwner` gate
- `handleJoinRequest` in the SDK rejected join requests from users who were already group members — after a client resets its local MLS state, the other side's group still has the old leaf, so the join is treated as a duplicate and rejected

## Root cause chain (complete)

1. MLS group fork: both clients at epoch 4 with different ratchet trees
2. Recovery deletes local group and sends join request
3. **SDK `handleJoinRequestEvent`** (line 1106): `isChannelOwner` gate — only server owner processes join requests. If the owner's client has the forked group, non-owners can never rejoin
4. **SDK `handleJoinRequest`** (line 1481): rejects join because requester is already a member in the (forked) group — the stale leaf is still in the ratchet tree
5. Recovery falls back to resync, but `handleResyncRequest` has a first-member-in-tree restriction that may not match
6. All recovery rounds exhaust → messages marked permanently unavailable

## Changes

### SDK: `handleJoinRequestEvent` — replace owner gate with tree-member check
The `isChannelOwner` gate is replaced with a check that the local user is the first member (index 0) in the ratchet tree. This is the same restriction `handleResyncRequest` already uses — it prevents concurrent epoch commits from multiple members without creating ownership deadlocks.

### SDK: `handleJoinRequest` — handle already-member case
When the requester is already a group member, the old leaf is removed before re-adding with a fresh key package. This is the same approach `handleResyncRequest` uses. The return type now includes `removeCommitBytes`.

### SDK: `handleExternalJoinRequest` — updated return type
Includes `removeCommitBytes` so callers can publish the removal event.

### Message store: all `handleExternalJoinRequest` callers
Updated to publish `mls_remove` when `removeCommitBytes` is present.

### Message store: `recoverEncryptedScope` — simplified fork detection
Removed the `mls_epoch` requirement from fork detection. After both recovery rounds fail, if we still have a local group with failed messages, try reset+rejoin. The old check required `mls_epoch` on messages, but messages created before PR #48 lack this field.

## Files Changed

| File | Change |
|------|--------|
| `sdk/src/client/encryptedChat.ts` | Replace owner gate, handle rejoin, update return type |
| `client/src/renderer/src/stores/messageStore.ts` | Update callers for removeCommitBytes, simplify fork detection |

## Test Plan

- [x] TypeScript typecheck passes
- [x] Production web build succeeds
- [ ] After deploy: hard refresh both clients, verify neon's messages become readable
- [ ] Verify new messages from both sides decrypt correctly after recovery


🤖 Generated with [Claude Code](https://claude.com/claude-code)