### PR TITLE
fix: force-create MLS group when fork recovery join fails

### DIFF
--- a/client/src/renderer/src/stores/messageStore.ts
+++ b/client/src/renderer/src/stores/messageStore.ts
@@ -2212,9 +2212,28 @@ async function recoverEncryptedScope(
     // with different ratchet tree states. Reset the local group entirely and
     // rejoin from scratch so we pick up the canonical group from whoever
     // responds to the join request.
-    if (encryptedChat.hasGroup(scope.targetId) && hasFailedMessagesInScope(scope, getState)) {
+    const shouldResetGroup =
+      encryptedChat.hasGroup(scope.targetId) && hasFailedMessagesInScope(scope, getState)
+
+    if (shouldResetGroup) {
       await encryptedChat.resetScope(scope.targetId)
+    }
+
+    if (shouldResetGroup || !encryptedChat.hasGroup(scope.targetId)) {
       await ensureEncryptedScopeMembership(scope).catch(() => {})
+
+      // If join/resync failed to re-establish the group, create a fresh one
+      // as a last resort. This breaks the deadlock when the other side can't
+      // process our join request (e.g. running old code, offline, or the
+      // first-member-in-tree restriction blocks them). Other members will
+      // rejoin via mls_request_join_all once they see the new group.
+      if (!encryptedChat.hasGroup(scope.targetId) && scope.kind === 'channel') {
+        await encryptedChat.createScopeGroup({ kind: 'channel', id: scope.targetId })
+        if (encryptedChat.hasGroup(scope.targetId)) {
+          const topic = `chat:channel:${scope.targetId}`
+          pushToChannel(topic, 'mls_request_join_all', {})
+        }
+      }
 
       if (encryptedChat.hasGroup(scope.targetId)) {
         await refreshEncryptedScope(scope, getState).catch(() => {})


### PR DESCRIPTION
## Summary

When recovery resets the local MLS group and the join/resync request to other members fails, create a fresh group as a last resort and broadcast `mls_request_join_all` so other members can rejoin.

This is the third fix in the fork recovery chain. PRs #48 and #49 fixed the handler-side gates, but if the other client is running old code or is unresponsive, the join still fails and the user is left with no group and can't send messages.

## What happens now

After both recovery rounds (history + resync) fail:

1. If we have a forked group, reset it
2. Try to join an existing group via join/resync requests  
3. If that fails and we still have no group, **create a fresh one** and broadcast `mls_request_join_all`
4. Other members see the broadcast and rejoin the new group
5. Messages from the fork period remain unavailable (forward secrecy) but new messages work

## Files Changed

| File | Change |
|------|--------|
| `client/src/renderer/src/stores/messageStore.ts` | Add force-create fallback in fork recovery |
| `sdk/src/client/encryptedChat.ts` | (carried from PR #49, no additional changes) |

## Test Plan

- [x] TypeScript typecheck passes
- [x] Production web build succeeds
- [ ] After deploy + hard refresh: PP can send messages again
- [ ] Neon's client receives `mls_request_join_all` and joins the new group


🤖 Generated with [Claude Code](https://claude.com/claude-code)