### PR TITLE
feat: Slate.js rich message composer with Discord-style UX

### DIFF
--- a/client/e2e/helpers/channel.ts
+++ b/client/e2e/helpers/channel.ts
@@ -41,7 +41,7 @@ export async function openThread(page: Page, messageText: string): Promise<void>
 export async function sendThreadReply(page: Page, text: string): Promise<void> {
   await sendMessageWithEncryptionRetry(
     page,
-    page.locator('.vesper-thread-composer-textarea'),
+    page.locator('.vesper-thread-panel [data-testid="message-input"]'),
     page.locator('.vesper-thread-feed [data-testid="message-row"]'),
     text,
     { errorLabel: 'thread reply' }
@@ -116,5 +116,7 @@ export async function startChannelTyping(page: Page): Promise<void> {
 
 export async function clearChannelComposer(page: Page): Promise<void> {
   const input = page.locator('[data-testid="message-input"]')
-  await input.fill('')
+  await input.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
 }

--- a/client/e2e/helpers/dm.ts
+++ b/client/e2e/helpers/dm.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test'
 import { sendAttachmentWithEncryptionRetry, sendMessageWithEncryptionRetry } from './sendRetry'
 import { waitForSocketConnected } from './wait'
+import { COMPOSER_SELECTOR, clearSlateEditor } from './slate'
 
 const ENCRYPTION_READY_TIMEOUT = 30_000
 const ENCRYPTION_POLL_INTERVAL = 500
@@ -25,7 +26,7 @@ export async function createDm(page: Page, username: string): Promise<void> {
   await page.click('button:has-text("Start Chat")')
 
   await page.waitForSelector('text=New Message', { state: 'hidden', timeout: 5_000 })
-  await page.waitForSelector('.vesper-composer-textarea', { timeout: 5_000 })
+  await page.waitForSelector(COMPOSER_SELECTOR, { timeout: 5_000 })
 
   // MLS encryption may not be ready yet -- dismiss error banners until it syncs
   await waitForEncryptionReady(page)
@@ -99,15 +100,13 @@ async function waitForOpenDm(page: Page, displayName: string): Promise<void> {
       .querySelector('.vesper-chat-header .text-text-primary.font-semibold')
       ?.textContent
       ?.trim()
-    return title === name && Boolean(document.querySelector('.vesper-composer-textarea'))
+    return title === name && Boolean(document.querySelector('[data-testid="message-input"]'))
   }, displayName, { timeout: 10_000 })
 
   await waitForSocketConnected(page)
   await waitForEncryptionReady(page)
 
   // Allow async scope watch to complete Phoenix channel subscription.
-  // joinChannelChat fires the watch asynchronously; this gives it
-  // time to connect before tests interact with the channel.
   await page.waitForTimeout(3_000)
 }
 
@@ -120,7 +119,7 @@ async function resolveDmState(
   | { kind: 'missing' }
 > {
   const header = page.locator('.vesper-chat-header .text-text-primary.font-semibold')
-  const composer = page.locator('.vesper-composer-textarea')
+  const composer = page.locator(COMPOSER_SELECTOR)
   const currentHeader =
     (await header.count().catch(() => 0)) > 0
       ? (await header.first().textContent().catch(() => null))?.trim()
@@ -164,7 +163,7 @@ async function waitForDmState(
 export async function sendDmMessage(page: Page, text: string): Promise<void> {
   await sendMessageWithEncryptionRetry(
     page,
-    page.locator('.vesper-composer-textarea'),
+    page.locator(COMPOSER_SELECTOR),
     page.getByTestId('message-row'),
     text,
     { timeout: ENCRYPTION_READY_TIMEOUT, errorLabel: 'DM' }
@@ -189,13 +188,13 @@ async function waitForEncryptionReady(page: Page): Promise<void> {
 }
 
 export async function startDmTyping(page: Page): Promise<void> {
-  const textarea = page.locator('.vesper-composer-textarea')
-  await textarea.type('typing...', { delay: 50 })
+  const input = page.locator(COMPOSER_SELECTOR)
+  await input.click()
+  await page.keyboard.type('typing...', { delay: 50 })
 }
 
 export async function clearDmComposer(page: Page): Promise<void> {
-  const textarea = page.locator('.vesper-composer-textarea')
-  await textarea.fill('')
+  await clearSlateEditor(page, page.locator(COMPOSER_SELECTOR))
 }
 
 export async function getDmMessages(page: Page): Promise<string[]> {
@@ -208,11 +207,9 @@ export async function uploadDmAttachment(
   filePath: string
 ): Promise<void> {
   // Send a probe message to confirm encryption is fully ready.
-  // The attachment upload can't retry if encryption fails mid-submit,
-  // so we validate the scope is operational first.
   await sendMessageWithEncryptionRetry(
     page,
-    page.locator('.vesper-composer-textarea'),
+    page.locator(COMPOSER_SELECTOR),
     page.getByTestId('message-row'),
     'attachment-probe',
     { timeout: 30_000, errorLabel: 'DM attachment probe' }
@@ -225,10 +222,10 @@ export async function uploadDmAttachment(
     timeout: 10_000,
   })
 
-  const textarea = page.locator('.vesper-composer-textarea')
+  const input = page.locator(COMPOSER_SELECTOR)
   await sendAttachmentWithEncryptionRetry(
     page,
-    textarea,
+    input,
     page.locator('[data-testid="message-row"] [data-testid="attachment"]'),
     { errorLabel: 'DM attachment' }
   )

--- a/client/e2e/helpers/emoji.ts
+++ b/client/e2e/helpers/emoji.ts
@@ -61,7 +61,7 @@ export async function useCustomEmojiInMessage(
 ): Promise<void> {
   const textarea = composer === 'channel'
     ? page.locator('[data-testid="message-input"]')
-    : page.locator('.vesper-composer-textarea')
+    : page.locator('[data-testid="message-input"]')
 
   await textarea.type(`:${emojiName}:`)
 }

--- a/client/e2e/helpers/message.ts
+++ b/client/e2e/helpers/message.ts
@@ -87,9 +87,11 @@ export async function editMessage(
   await row.hover()
   await row.locator('[data-testid="edit-message"]').click()
 
-  const editInput = row.locator('[data-testid="edit-input"]')
+  const editInput = row.locator('[data-slate-editor]')
   await editInput.waitFor({ state: 'visible', timeout: 10_000 })
-  await editInput.fill(newText)
+  await editInput.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.type(newText)
 
   const deadline = Date.now() + 15_000
   while (Date.now() < deadline) {

--- a/client/e2e/helpers/sendRetry.ts
+++ b/client/e2e/helpers/sendRetry.ts
@@ -43,7 +43,9 @@ export async function sendMessageWithEncryptionRetry(
     }
 
     if (!sent) {
-      await inputLocator.fill(text)
+      await inputLocator.click()
+      await page.keyboard.press('Meta+a')
+      await page.keyboard.type(text)
       await inputLocator.press('Enter')
       sent = true
     }
@@ -59,7 +61,9 @@ export async function sendMessageWithEncryptionRetry(
     if (result === 'error') {
       sent = false
       await dismissEncryptionAlert(page)
-      await inputLocator.fill('')
+      await inputLocator.click()
+      await page.keyboard.press('Meta+a')
+      await page.keyboard.press('Backspace')
       await page.waitForTimeout(POLL_INTERVAL)
       continue
     }

--- a/client/e2e/helpers/slate.ts
+++ b/client/e2e/helpers/slate.ts
@@ -1,0 +1,31 @@
+import type { Locator, Page } from '@playwright/test'
+
+/**
+ * The Slate editor selector used across all E2E tests.
+ * Matches the data-testid on the Editable component.
+ */
+export const COMPOSER_SELECTOR = '[data-testid="message-input"]'
+export const THREAD_COMPOSER_SELECTOR = '.vesper-thread-panel [data-testid="message-input"]'
+
+/**
+ * Type text into a Slate contentEditable editor.
+ * Replaces the old textarea .fill() pattern.
+ */
+export async function fillSlateEditor(page: Page, locator: Locator, text: string): Promise<void> {
+  await locator.click()
+  await page.keyboard.press('Meta+a')
+  if (text) {
+    await page.keyboard.type(text)
+  } else {
+    await page.keyboard.press('Backspace')
+  }
+}
+
+/**
+ * Clear a Slate contentEditable editor.
+ */
+export async function clearSlateEditor(page: Page, locator: Locator): Promise<void> {
+  await locator.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+}

--- a/client/e2e/tests/p1-member-presence.spec.ts
+++ b/client/e2e/tests/p1-member-presence.spec.ts
@@ -114,7 +114,7 @@ test.describe('P1: Member list and presence', () => {
     await messageBtn.click()
 
     // Should navigate to DM view with charlie
-    await alice.page.waitForSelector('.vesper-composer-textarea', { timeout: 10_000 })
+    await alice.page.waitForSelector('[data-testid="message-input"]', { timeout: 10_000 })
     await waitForAppShell(alice.page)
   })
 })

--- a/client/e2e/tests/p1-mentions.spec.ts
+++ b/client/e2e/tests/p1-mentions.spec.ts
@@ -34,27 +34,33 @@ test.describe('P1: Mentions', () => {
     await bob.context.close()
   })
 
-  test('Composer rich preview renders markdown while input keeps raw text', async () => {
+  test('Composer renders markdown decorations inline', async () => {
     const input = alice.page.locator('[data-testid="message-input"]')
-    const preview = alice.page.locator('[data-testid="composer-rich-preview"]')
 
-    await input.fill('**bold** _italic_ ~~gone~~')
+    await input.click()
+    await alice.page.keyboard.type('**bold** *italic* ~~gone~~')
 
-    await expect(preview.locator('strong')).toHaveText('bold')
-    await expect(preview.locator('em')).toHaveText('italic')
-    await expect(preview.locator('del')).toHaveText('gone')
-    await expect(input).toHaveValue('**bold** _italic_ ~~gone~~')
+    // Slate decorations render bold/italic/strikethrough inline
+    await expect(input.locator('strong.vesper-slate-bold')).toHaveText('bold')
+    await expect(input.locator('em.vesper-slate-italic')).toHaveText('italic')
+    await expect(input.locator('s.vesper-slate-strikethrough')).toHaveText('gone')
 
-    await input.fill('')
+    // Clear
+    await alice.page.keyboard.press('Meta+a')
+    await alice.page.keyboard.press('Backspace')
   })
 
   test('Member mention autocomplete inserts correct syntax (R-MSG-4)', async () => {
     const input = alice.page.locator('[data-testid="message-input"]')
-    const preview = alice.page.locator('[data-testid="composer-rich-preview"]')
     const autocomplete = alice.page.locator('[data-testid="composer-autocomplete"]')
     const toggleMembers = alice.page.locator('[data-testid="toggle-members"]')
     const memberList = alice.page.locator('[data-testid="member-list"]')
-    await input.fill('')
+
+    // Clear editor
+    await input.click()
+    await alice.page.keyboard.press('Meta+a')
+    await alice.page.keyboard.press('Backspace')
+
     const suffix = 'mention-sync-rmsg4'
 
     if (await toggleMembers.isVisible().catch(() => false)) {
@@ -67,27 +73,28 @@ test.describe('P1: Mentions', () => {
     ).toBeVisible()
 
     // Type @ to trigger autocomplete
-    await input.type('@bob')
+    await input.click()
+    await alice.page.keyboard.type('@bob')
     await expect(autocomplete).toBeVisible()
 
     const bobOption = autocomplete.getByRole('option', { name: USERS.bob.username })
     await expect(bobOption).toBeVisible()
     await bobOption.click()
 
-    await expect(preview).toContainText('@bob')
+    // Mention should appear as a void node chip
+    await expect(input.locator('.vesper-slate-mention')).toContainText('@bob')
 
     // Ensure the message includes stable plain text we can assert on both clients.
-    await input.type(` ${suffix}`)
+    await alice.page.keyboard.type(` ${suffix}`)
 
-    // Send via keyboard to avoid flaky pointer interception by transient overlays.
-    await input.press('Enter')
+    // Send via keyboard
+    await alice.page.keyboard.press('Enter')
     await waitForMessage(alice.page, suffix)
     await waitForMessage(bob.page, suffix)
 
     // Bob should see the message with a mention highlight
     const mentionHighlight = bob.page.locator('[data-testid="message-row"] .vesper-mention-highlight, [data-testid="message-row"] .mention')
     const hasMention = await mentionHighlight.count() > 0
-    // If the app renders mentions with highlight, verify it; otherwise just verify the message arrived
     if (!hasMention) {
       await waitForMessage(bob.page, suffix)
     }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -33,6 +33,9 @@
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "slate": "^0.124.0",
+        "slate-history": "^0.113.1",
+        "slate-react": "^0.124.0",
         "tailwindcss": "^4.2.1",
         "zustand": "^5.0.11"
       },
@@ -1547,6 +1550,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -4255,6 +4264,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5401,6 +5416,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dmg-builder": {
@@ -7520,6 +7548,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==",
+      "license": "MIT"
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -7552,6 +7586,15 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8104,7 +8147,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -10835,6 +10877,15 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -11008,6 +11059,63 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slate": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.124.0.tgz",
+      "integrity": "sha512-yhtJ0MSV+Z63UTaZtGZDp1goO9XZb5VGER9bmwX+38yJUb7nijPkYEcxD5mpezsSLqL6NedUb4wyvoZa+HDWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/slate-dom": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.124.0.tgz",
+      "integrity": "sha512-dPabNlzo67xWRNFT5HtSc0M/F9mfiQSnjJAEx0Uzk7oC++WaRuBy897F+rNzfvM+zH9exMc3hsTMtM7jGDhIiQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.121.0"
+      }
+    },
+    "node_modules/slate-history": {
+      "version": "0.113.1",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.113.1.tgz",
+      "integrity": "sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.124.0.tgz",
+      "integrity": "sha512-NLN6ME64ChOgJtiVTKwISS1sI/Y8/qN1cwmDTZM9AQJCl+jR3XNCvDsKNrW0kJU+1G3NgIGaYoVWhgIVEIL+Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.121.0",
+        "slate-dom": ">=0.119.1"
       }
     },
     "node_modules/slice-ansi": {
@@ -11558,6 +11666,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
     },
     "node_modules/tiny-typed-emitter": {
       "version": "2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,9 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "slate": "^0.124.0",
+    "slate-history": "^0.113.1",
+    "slate-react": "^0.124.0",
     "tailwindcss": "^4.2.1",
     "zustand": "^5.0.11"
   }

--- a/client/src/renderer/src/components/chat/ComposerForm.tsx
+++ b/client/src/renderer/src/components/chat/ComposerForm.tsx
@@ -29,6 +29,8 @@ interface Props {
   onEmojiSelect: (emoji: string, item?: PickerEmoji) => void
   onFileSelect: ChangeEventHandler<HTMLInputElement>
   onRemoveStagedFile: (id: string) => void
+  onToggleStagedFileSpoiler: (id: string) => void
+  onToggleStagedFileAnonymous: (id: string) => void
   onSend: () => void
   onToggleEmojiPicker: () => void
   replyingTo: Message | null
@@ -61,6 +63,8 @@ export default function ComposerForm({
   onEmojiSelect,
   onFileSelect,
   onRemoveStagedFile,
+  onToggleStagedFileSpoiler,
+  onToggleStagedFileAnonymous,
   onSend,
   onToggleEmojiPicker,
   replyingTo,
@@ -93,7 +97,7 @@ export default function ComposerForm({
         </div>
       )}
 
-      {triggerQuery && autocompleteItems.length > 0 && (
+      {triggerQuery !== null && autocompleteItems.length > 0 && (
         <ComposerAutocomplete
           anchorRef={editorContainerRef}
           query={triggerQuery}
@@ -111,6 +115,8 @@ export default function ComposerForm({
         onCancelReply={onCancelReply}
         stagedFiles={stagedFiles}
         onRemoveStagedFile={onRemoveStagedFile}
+        onToggleSpoiler={onToggleStagedFileSpoiler}
+        onToggleAnonymous={onToggleStagedFileAnonymous}
       >
         <div className="vesper-composer-controls">
           <button

--- a/client/src/renderer/src/components/chat/ComposerForm.tsx
+++ b/client/src/renderer/src/components/chat/ComposerForm.tsx
@@ -1,103 +1,55 @@
 import type {
   ChangeEventHandler,
   DragEventHandler,
-  FormEventHandler,
-  KeyboardEventHandler,
-  MouseEventHandler,
-  RefObject,
-  UIEventHandler
+  RefObject
 } from 'react'
-import { Suspense } from 'react'
 import { Loader2, Paperclip, SendHorizonal, Smile } from 'lucide-react'
-import type { DmConversation } from '../../stores/dmStore'
 import type { Message } from '../../stores/messageStore'
-import type { Member, Server } from '../../stores/serverStore'
 import type { PickerEmoji } from './EmojiPicker'
 import EmojiPicker from './EmojiPicker'
 import ComposerAutocomplete, { type ComposerAutocompleteItem } from './ComposerAutocomplete'
-import type { ComposerMentionDraft } from './composerAutocompleteUtils'
 import ComposerShell, { type StagedFile } from './message/ComposerShell'
-import lazyWithRetry from '../../utils/lazyWithRetry'
-
-const ComposerRichTextPreview = lazyWithRetry(() => import('./ComposerRichTextPreview'))
-
-const CODE_FENCE_PREVIEW_PATTERN = /^```(?!mermaid\b)([^\n`]*)\n[\s\S]*\n```$/i
-const MENTION_OR_TOKEN_PATTERN =
-  /<@([0-9a-f-]{36}|everyone)>|<#([0-9a-f-]{36})>|<(a?):([a-zA-Z0-9_~-]{2,32}):([a-zA-Z0-9_-]+)>/
-const MARKDOWN_PREVIEW_PATTERN =
-  /(^|\s)([*_~`>#-]|\d+\.)|\[[^\]]+\]\([^)]+\)|\*\*[^*]+\*\*|__[^_]+__|~~[^~]+~~|`[^`]+`/
-
-function shouldShowRichPreview(
-  content: string,
-  mentionDrafts: ComposerMentionDraft[]
-): boolean {
-  if (content.trim().length === 0) {
-    return false
-  }
-
-  return (
-    mentionDrafts.length > 0 ||
-    CODE_FENCE_PREVIEW_PATTERN.test(content) ||
-    MENTION_OR_TOKEN_PATTERN.test(content) ||
-    MARKDOWN_PREVIEW_PATTERN.test(content)
-  )
-}
 
 interface Props {
   autocompleteItems: ComposerAutocompleteItem[]
-  content: string
-  conversation?: DmConversation | null
   dragActive: boolean
+  editorContainerRef: RefObject<HTMLDivElement | null>
   emojiButtonRef: RefObject<HTMLButtonElement | null>
   encryptionError: string | null
   fileButtonTestId?: string
   fileInputRef: RefObject<HTMLInputElement | null>
-  members: Member[]
-  mentionDrafts: ComposerMentionDraft[]
   onAutocompleteHover: (index: number) => void
   onAutocompleteSelect: (item: ComposerAutocompleteItem) => void
   onCancelReply: () => void
   onClearEncryptionError: () => void
-  onDragEnter: DragEventHandler<HTMLFormElement>
-  onDragLeave: DragEventHandler<HTMLFormElement>
-  onDrop: DragEventHandler<HTMLFormElement>
+  onDragEnter: DragEventHandler<HTMLDivElement>
+  onDragLeave: DragEventHandler<HTMLDivElement>
+  onDrop: DragEventHandler<HTMLDivElement>
   onEmojiClose: () => void
   onEmojiSelect: (emoji: string, item?: PickerEmoji) => void
   onFileSelect: ChangeEventHandler<HTMLInputElement>
   onRemoveStagedFile: (id: string) => void
-  onSubmit: FormEventHandler<HTMLFormElement>
-  onTextareaChange: ChangeEventHandler<HTMLTextAreaElement>
-  onTextareaClick: MouseEventHandler<HTMLTextAreaElement>
-  onTextareaKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
-  onTextareaKeyUp: KeyboardEventHandler<HTMLTextAreaElement>
-  onTextareaScroll: UIEventHandler<HTMLTextAreaElement>
+  onSend: () => void
   onToggleEmojiPicker: () => void
-  placeholder: string
-  previewRef: RefObject<HTMLDivElement | null>
   replyingTo: Message | null
   selectedAutocompleteIndex: number
   sendButtonTestId?: string
-  server?: Server | null
   showEmojiPicker: boolean
   stagedFiles: StagedFile[]
-  textareaRef: RefObject<HTMLTextAreaElement | null>
-  textareaTestId?: string
   triggerQuery: string | null
   uploading: boolean
   canSend: boolean
+  children: React.ReactNode
 }
 
 export default function ComposerForm({
   autocompleteItems,
-  content,
-  conversation,
   dragActive,
+  editorContainerRef,
   emojiButtonRef,
   encryptionError,
   fileButtonTestId,
   fileInputRef,
-  members,
-  mentionDrafts,
   onAutocompleteHover,
   onAutocompleteSelect,
   onCancelReply,
@@ -109,32 +61,20 @@ export default function ComposerForm({
   onEmojiSelect,
   onFileSelect,
   onRemoveStagedFile,
-  onSubmit,
-  onTextareaChange,
-  onTextareaClick,
-  onTextareaKeyDown,
-  onTextareaKeyUp,
-  onTextareaScroll,
+  onSend,
   onToggleEmojiPicker,
-  placeholder,
-  previewRef,
   replyingTo,
   selectedAutocompleteIndex,
   sendButtonTestId,
-  server,
   showEmojiPicker,
   stagedFiles,
-  textareaRef,
-  textareaTestId,
   triggerQuery,
   uploading,
-  canSend
+  canSend,
+  children,
 }: Props): React.JSX.Element {
-  const showRichPreview = shouldShowRichPreview(content, mentionDrafts)
-
   return (
-    <form
-      onSubmit={onSubmit}
+    <div
       onDragEnter={onDragEnter}
       onDragOver={(event) => {
         event.preventDefault()
@@ -155,7 +95,7 @@ export default function ComposerForm({
 
       {triggerQuery && autocompleteItems.length > 0 && (
         <ComposerAutocomplete
-          anchorRef={textareaRef}
+          anchorRef={editorContainerRef}
           query={triggerQuery}
           items={autocompleteItems}
           selectedIndex={selectedAutocompleteIndex}
@@ -208,36 +148,13 @@ export default function ComposerForm({
               />
             )}
           </div>
-          <div className={`vesper-composer-input-stack${showRichPreview ? ' vesper-composer-input-stack-rich' : ''}`}>
-            {showRichPreview && (
-              <Suspense fallback={null}>
-                <ComposerRichTextPreview
-                  containerRef={previewRef}
-                  content={content}
-                  members={members}
-                  mentionDrafts={mentionDrafts}
-                  conversation={conversation}
-                  server={server}
-                />
-              </Suspense>
-            )}
-            <textarea
-              ref={textareaRef}
-              data-testid={textareaTestId}
-              value={content}
-              onChange={onTextareaChange}
-              onClick={onTextareaClick}
-              onKeyUp={onTextareaKeyUp}
-              onKeyDown={onTextareaKeyDown}
-              onScroll={onTextareaScroll}
-              placeholder={placeholder}
-              rows={1}
-              className={showRichPreview ? 'vesper-composer-textarea vesper-composer-textarea-rich' : 'vesper-composer-textarea'}
-            />
+          <div ref={editorContainerRef} className="vesper-composer-input-stack">
+            {children}
           </div>
           <button
             data-testid={sendButtonTestId}
-            type="submit"
+            type="button"
+            onClick={onSend}
             disabled={!canSend || uploading}
             className="vesper-composer-send"
           >
@@ -245,6 +162,6 @@ export default function ComposerForm({
           </button>
         </div>
       </ComposerShell>
-    </form>
+    </div>
   )
 }

--- a/client/src/renderer/src/components/chat/FilePreview.tsx
+++ b/client/src/renderer/src/components/chat/FilePreview.tsx
@@ -38,6 +38,8 @@ export default function FilePreview({ file }: Props): React.JSX.Element {
   const isAudio = effectiveType.startsWith('audio/')
   const isVideo = effectiveType.startsWith('video/')
   const isMedia = isImage || isAudio || isVideo
+  const isSpoiler = file.name.startsWith('SPOILER_')
+  const [spoilerRevealed, setSpoilerRevealed] = useState(false)
 
   const { ref: visibilityRef, hasBeenVisible, isFarAway } = useVisibility()
 
@@ -269,18 +271,34 @@ export default function FilePreview({ file }: Props): React.JSX.Element {
           </div>
         ) : previewUrl ? (
           <>
-            <button
-              type="button"
-              onClick={() => setShowLightbox(true)}
-              className="block group"
-            >
-              <img
-                src={previewUrl}
-                alt={file.name}
-                className="max-w-sm max-h-80 rounded-lg border border-border object-contain cursor-zoom-in group-hover:brightness-90 transition-all"
-                onError={() => setError(true)}
-              />
-            </button>
+            {isSpoiler && !spoilerRevealed ? (
+              <button
+                type="button"
+                onClick={() => setSpoilerRevealed(true)}
+                className="vesper-file-spoiler-overlay"
+              >
+                <img
+                  src={previewUrl}
+                  alt={file.name}
+                  className="max-w-sm max-h-80 rounded-lg border border-border object-contain"
+                  onError={() => setError(true)}
+                />
+                <span className="vesper-file-spoiler-label">SPOILER</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => isSpoiler ? setSpoilerRevealed(false) : setShowLightbox(true)}
+                className="block group"
+              >
+                <img
+                  src={previewUrl}
+                  alt={file.name}
+                  className="max-w-sm max-h-80 rounded-lg border border-border object-contain cursor-zoom-in group-hover:brightness-90 transition-all"
+                  onError={() => setError(true)}
+                />
+              </button>
+            )}
 
             {showLightbox && (
               <ImageLightbox
@@ -293,7 +311,6 @@ export default function FilePreview({ file }: Props): React.JSX.Element {
             )}
           </>
         ) : !hasBeenVisible ? (
-          // Placeholder before the element scrolls into view
           <div className="w-48 h-32 rounded-lg bg-bg-tertiary/50 border border-border" />
         ) : null}
       </div>

--- a/client/src/renderer/src/components/chat/MarkdownContent.tsx
+++ b/client/src/renderer/src/components/chat/MarkdownContent.tsx
@@ -345,7 +345,18 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkMath]}
           rehypePlugins={[rehypeKatex]}
-          urlTransform={(url) => url.startsWith('emoji:') || url.startsWith('twemoji:') ? url : defaultUrlTransform(url)}
+          urlTransform={(url) => {
+            if (
+              url.startsWith('emoji:') ||
+              url.startsWith('twemoji:') ||
+              url.startsWith('spoiler:') ||
+              url.startsWith('mention:') ||
+              url.startsWith('channel:')
+            ) {
+              return url
+            }
+            return defaultUrlTransform(url)
+          }}
           components={components}
         >
           {processed}

--- a/client/src/renderer/src/components/chat/MarkdownContent.tsx
+++ b/client/src/renderer/src/components/chat/MarkdownContent.tsx
@@ -14,6 +14,7 @@ import ProfilePopout from '../profile/ProfilePopout'
 import { extractMarkdownCodeBlock } from './MarkdownCodeBlock'
 import MermaidBlock from './MermaidBlock'
 import EmojiGlyph from './message/EmojiGlyph'
+import SpoilerReveal from './message/SpoilerReveal'
 
 interface Props {
   content: string
@@ -74,6 +75,16 @@ function preprocessUnicodeEmoji(text: string): string {
   })
 }
 
+function preprocessSpoilers(text: string): string {
+  // Convert ||spoiler text|| to a link with spoiler: protocol
+  // This preserves the content through react-markdown and lets us
+  // render it with the SpoilerReveal component.
+  return text.replace(/\|\|(.+?)\|\|/g, (_match, content: string) => {
+    const encoded = encodeURIComponent(content)
+    return `[${content}](spoiler:${encoded})`
+  })
+}
+
 export default function MarkdownContent({ content }: Props): React.JSX.Element {
   const members = useServerStore((s) => s.members)
   const activeServer = useServerStore((s) => s.servers.find((server) => server.id === s.activeServerId))
@@ -124,10 +135,12 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
     (entry, index, collection) =>
       collection.findIndex((candidate) => candidate.id === entry.id) === index
   )
-  const processed = preprocessUnicodeEmoji(
-    preprocessCustomEmoji(
-      preprocessChannels(preprocessMentions(content, dedupedMentionUsers), channels),
-      customEmojis
+  const processed = preprocessSpoilers(
+    preprocessUnicodeEmoji(
+      preprocessCustomEmoji(
+        preprocessChannels(preprocessMentions(content, dedupedMentionUsers), channels),
+        customEmojis
+      )
     )
   )
   const mentionedUser = (() => {
@@ -265,6 +278,10 @@ export default function MarkdownContent({ content }: Props): React.JSX.Element {
             {children}
           </button>
         )
+      }
+
+      if (href?.startsWith('spoiler:')) {
+        return <SpoilerReveal>{children}</SpoilerReveal>
       }
 
       return (

--- a/client/src/renderer/src/components/chat/MessageInput.tsx
+++ b/client/src/renderer/src/components/chat/MessageInput.tsx
@@ -14,15 +14,12 @@ import {
   buildChannelSuggestions,
   buildEmojiSuggestions,
   buildMentionSuggestions,
-  detectComposerTrigger,
-  serializeComposerMentions,
-  type ComposerMentionDraft,
-  type ComposerTriggerMatch
 } from './composerAutocompleteUtils'
 import type { Message } from '../../stores/messageStore'
 import { createVesperEditor } from './slate/createVesperEditor'
 import { serializeToMarkdown } from './slate/serialize'
 import { emptyDocument } from './slate/types'
+import { detectSlateTrigger, insertAutocompleteResult } from './slate/autocomplete'
 import VesperEditable from './slate/VesperEditable'
 
 let stagedIdCounter = 0
@@ -35,8 +32,7 @@ interface Props {
 export default function MessageInput({ scope }: Props): React.JSX.Element {
   const [content, setContent] = useState('')
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
-  const [trigger, setTrigger] = useState<ComposerTriggerMatch | null>(null)
-  const [mentionDrafts, setMentionDrafts] = useState<ComposerMentionDraft[]>([])
+  const [trigger, setTrigger] = useState<{ type: 'mention' | 'channel' | 'emoji'; query: string; start: number } | null>(null)
   const [selectedAutocompleteIndex, setSelectedAutocompleteIndex] = useState(0)
   const [uploading, setUploading] = useState(false)
   const [stagedFiles, setStagedFiles] = useState<StagedFile[]>([])
@@ -74,7 +70,7 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
 
-  // Slate editor — stable across re-renders, reset on scope change
+  // Slate editor — stable across re-renders, new instance on scope change
   const editor = useMemo(() => {
     const ed = createVesperEditor({ onSubmit: () => {} })
     ed.children = emptyDocument()
@@ -84,93 +80,71 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
 
   const slateValue = useMemo(() => emptyDocument(), [scopeId])
 
+  // --- Typing indicators ---
   const handleTyping = useCallback(() => {
     if (!isTypingRef.current) {
       isTypingRef.current = true
-      if (isChannel) {
-        sendTypingStart(scopeId)
-      } else {
-        sendDmTypingStart(scopeId)
-      }
+      if (isChannel) sendTypingStart(scopeId)
+      else sendDmTypingStart(scopeId)
     }
-
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current)
-    }
-
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current)
     typingTimeoutRef.current = setTimeout(() => {
       isTypingRef.current = false
-      if (isChannel) {
-        sendTypingStop(scopeId)
-      } else {
-        sendDmTypingStop(scopeId)
-      }
+      if (isChannel) sendTypingStop(scopeId)
+      else sendDmTypingStop(scopeId)
     }, 2000)
   }, [isChannel, scopeId, sendTypingStart, sendTypingStop, sendDmTypingStart, sendDmTypingStop])
 
+  // --- File staging ---
   const stageFiles = useCallback((files: Iterable<File>): void => {
     const entries = Array.from(files)
     if (entries.length === 0) return
-
     setStagedFiles((prev) => {
       const existingKeys = new Set(
-        prev.map((entry) => `${entry.file.name}:${entry.file.size}:${entry.file.lastModified}`)
+        prev.map((e) => `${e.file.name}:${e.file.size}:${e.file.lastModified}`)
       )
       const next = [...prev]
       for (const file of entries) {
         const key = `${file.name}:${file.size}:${file.lastModified}`
-        if (existingKeys.has(key)) continue
-        existingKeys.add(key)
-        next.push({ file, id: `staged-${++stagedIdCounter}` })
+        if (!existingKeys.has(key)) {
+          existingKeys.add(key)
+          next.push({ file, id: `staged-${++stagedIdCounter}` })
+        }
       }
       return next
     })
   }, [])
 
   const removeStagedFile = (id: string): void => {
-    setStagedFiles((prev) => prev.filter((entry) => entry.id !== id))
+    setStagedFiles((prev) => prev.filter((e) => e.id !== id))
   }
 
   const uploadAndSendFile = async (file: File, text: string | undefined): Promise<boolean> => {
     if (!canUseE2EE) {
-      useMessageStore.setState({
-        encryptionError: 'Approve this device to send encrypted messages.'
-      })
+      useMessageStore.setState({ encryptionError: 'Approve this device to send encrypted messages.' })
       return false
     }
-
     const preparedAttachment = await prepareMessageAttachment(file)
     if (!preparedAttachment) return false
-
     const replyTo = useMessageStore.getState().replyingTo
     const parentId = replyTo?.id || undefined
     const resolvedScope = scope.kind === 'dm'
       ? { ...scope, channelId: conversations.find(c => c.id === scope.id)?.channel_id ?? undefined }
       : scope
-
     try {
       await getRendererEncryptedChat().sendPayload(
         resolvedScope,
-        {
-          v: 1,
-          type: 'file',
-          text: text ?? null,
-          file: preparedAttachment.file
-        },
-        {
-          attachmentIds: preparedAttachment.attachmentIds,
-          ...(parentId ? { parentMessageId: parentId } : {})
-        }
+        { v: 1, type: 'file', text: text ?? null, file: preparedAttachment.file },
+        { attachmentIds: preparedAttachment.attachmentIds, ...(parentId ? { parentMessageId: parentId } : {}) }
       )
       return true
     } catch {
-      useMessageStore.setState({
-        encryptionError: 'File could not be encrypted. Please try again.'
-      })
+      useMessageStore.setState({ encryptionError: 'File could not be encrypted. Please try again.' })
       return false
     }
   }
 
+  // --- Autocomplete ---
   const autocompleteItems = trigger
     ? (
         trigger.type === 'mention'
@@ -187,57 +161,22 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     if (!trigger) return
     const item = autocompleteItems[index]
     if (!item) return
-
-    const replacement =
-      item.type === 'user'
-        ? `@${item.label}`
-        : item.type === 'everyone'
-          ? '@everyone'
-          : item.value
-
-    // For Slate, we need to delete the trigger text and insert the replacement
-    // For now, use the content string approach (Phase 3 will use Slate void nodes)
-    const cursorPos = content.length
-    const start = content.lastIndexOf(
-      trigger.type === 'mention' ? '@' : trigger.type === 'channel' ? '#' : ':'
-    )
-    if (start >= 0) {
-      const before = content.slice(0, start)
-      const after = content.slice(cursorPos)
-      const newContent = before + replacement + ' ' + after
-
-      if (item.type === 'user' || item.type === 'everyone') {
-        setMentionDrafts((current) => [...current, { display: replacement, syntax: item.value }])
-      }
-
-      // Reset editor content
-      resetEditorContent(newContent)
-    }
-
+    insertAutocompleteResult(editor, item, trigger.start)
     setTrigger(null)
     setSelectedAutocompleteIndex(0)
   }
 
-  const resetEditorContent = (text: string): void => {
-    // Clear editor and set new text
-    const point = { path: [0, 0], offset: 0 }
-    Transforms.delete(editor, {
-      at: { anchor: Editor.start(editor, []), focus: Editor.end(editor, []) }
-    })
-    // Remove all nodes except first
-    while (editor.children.length > 1) {
-      Transforms.removeNodes(editor, { at: [editor.children.length - 1] })
+  const updateAutocompleteState = (): void => {
+    const nextTrigger = detectSlateTrigger(editor)
+    if (!isChannel && nextTrigger?.type === 'channel') {
+      setTrigger(null)
+    } else {
+      setTrigger(nextTrigger)
     }
-    // Set text of the remaining line
-    const firstChild = editor.children[0]
-    if (firstChild && 'children' in firstChild) {
-      Transforms.insertText(editor, text, { at: { path: [0, 0], offset: 0 } })
-    }
-    // Move cursor to end
-    Transforms.select(editor, Editor.end(editor, []))
-    setContent(text)
+    setSelectedAutocompleteIndex(0)
   }
 
+  // --- Editor helpers ---
   const clearEditor = (): void => {
     Transforms.delete(editor, {
       at: { anchor: Editor.start(editor, []), focus: Editor.end(editor, []) }
@@ -245,7 +184,6 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     while (editor.children.length > 1) {
       Transforms.removeNodes(editor, { at: [editor.children.length - 1] })
     }
-    // Ensure the remaining node is a clean empty line
     const remaining = editor.children[0]
     if (remaining && 'children' in remaining && Node.string(remaining) !== '') {
       Transforms.delete(editor, { at: [0] })
@@ -255,68 +193,54 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     setContent('')
   }
 
-  const updateAutocompleteState = (value: string, cursorPos: number): void => {
-    const nextTrigger = detectComposerTrigger(value, cursorPos)
-    if (!isChannel && nextTrigger?.type === 'channel') {
-      setTrigger(null)
-    } else {
-      setTrigger(nextTrigger)
-    }
-    setSelectedAutocompleteIndex(0)
-  }
-
-  // Drag-and-drop handlers
+  // --- Drag-and-drop ---
   useEffect(() => {
     const hasFiles = (dt: DataTransfer | null): boolean =>
       Boolean(dt?.types && Array.from(dt.types).includes('Files'))
 
-    const handleWindowDragEnter = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) return
-      event.preventDefault()
+    const onDragEnter = (e: DragEvent): void => {
+      if (!hasFiles(e.dataTransfer)) return
+      e.preventDefault()
       dragDepthRef.current += 1
       setDragActive(true)
     }
-
-    const handleWindowDragOver = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) return
-      event.preventDefault()
-      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+    const onDragOver = (e: DragEvent): void => {
+      if (!hasFiles(e.dataTransfer)) return
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
       setDragActive(true)
     }
-
-    const handleWindowDragLeave = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) return
-      event.preventDefault()
+    const onDragLeave = (e: DragEvent): void => {
+      if (!hasFiles(e.dataTransfer)) return
+      e.preventDefault()
       dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
       if (dragDepthRef.current === 0) setDragActive(false)
     }
-
-    const handleWindowDrop = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) return
-      event.preventDefault()
+    const onDrop = (e: DragEvent): void => {
+      if (!hasFiles(e.dataTransfer)) return
+      e.preventDefault()
       dragDepthRef.current = 0
       setDragActive(false)
-      if (!uploading) stageFiles(Array.from(event.dataTransfer?.files ?? []))
+      if (!uploading) stageFiles(Array.from(e.dataTransfer?.files ?? []))
     }
 
-    window.addEventListener('dragenter', handleWindowDragEnter)
-    window.addEventListener('dragover', handleWindowDragOver)
-    window.addEventListener('dragleave', handleWindowDragLeave)
-    window.addEventListener('drop', handleWindowDrop)
-
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('drop', onDrop)
     return () => {
-      window.removeEventListener('dragenter', handleWindowDragEnter)
-      window.removeEventListener('dragover', handleWindowDragOver)
-      window.removeEventListener('dragleave', handleWindowDragLeave)
-      window.removeEventListener('drop', handleWindowDrop)
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('drop', onDrop)
     }
   }, [stageFiles, uploading])
 
+  // --- Submit ---
   const handleSubmit = async (): Promise<void> => {
     const markdown = serializeToMarkdown(editor.children).trim()
     const hasText = markdown.length > 0
     const hasFiles = stagedFiles.length > 0
-
     if (!hasText && !hasFiles) return
 
     if (hasFiles) {
@@ -324,16 +248,11 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       try {
         for (let i = 0; i < stagedFiles.length; i++) {
           const text = i === 0 ? markdown : undefined
-          const serializedText = text ? serializeComposerMentions(text, mentionDrafts) : undefined
-          const ok = await uploadAndSendFile(stagedFiles[i].file, serializedText)
-          if (!ok) {
-            setUploading(false)
-            return
-          }
+          const ok = await uploadAndSendFile(stagedFiles[i].file, text)
+          if (!ok) { setUploading(false); return }
         }
         setStagedFiles([])
         clearEditor()
-        setMentionDrafts([])
         useMessageStore.getState().setReplyingTo(null)
       } catch {
         // ignore
@@ -342,14 +261,12 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       }
     } else {
       const send = isChannel ? sendMessage : sendDmMessage
-      send(scopeId, serializeComposerMentions(markdown, mentionDrafts))
+      send(scopeId, markdown)
       clearEditor()
-      setMentionDrafts([])
     }
 
     setTrigger(null)
     setSelectedAutocompleteIndex(0)
-
     if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current)
     if (isTypingRef.current) {
       isTypingRef.current = false
@@ -358,19 +275,17 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     }
   }
 
+  // --- Key handling ---
   const handleKeyDown = (event: React.KeyboardEvent): void => {
-    // Autocomplete navigation
     if (trigger && autocompleteItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
-        setSelectedAutocompleteIndex((current) => (current + 1) % autocompleteItems.length)
+        setSelectedAutocompleteIndex((c) => (c + 1) % autocompleteItems.length)
         return
       }
       if (event.key === 'ArrowUp') {
         event.preventDefault()
-        setSelectedAutocompleteIndex((current) =>
-          current <= 0 ? autocompleteItems.length - 1 : current - 1
-        )
+        setSelectedAutocompleteIndex((c) => c <= 0 ? autocompleteItems.length - 1 : c - 1)
         return
       }
       if (event.key === 'Enter' || event.key === 'Tab') {
@@ -385,29 +300,20 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       }
     }
 
-    // Submit on Enter (not Shift+Enter)
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
       void handleSubmit()
       return
     }
 
-    // Edit last message on ArrowUp in empty editor
     if (
       event.key === 'ArrowUp' &&
-      !event.shiftKey &&
-      !event.altKey &&
-      !event.metaKey &&
-      !event.ctrlKey &&
-      !content &&
-      stagedFiles.length === 0 &&
-      !replyingTo &&
-      !uploading
+      !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey &&
+      !content && stagedFiles.length === 0 && !replyingTo && !uploading
     ) {
       const lastEditableMessage = [...messages]
         .reverse()
-        .find((message) => message.sender_id === myUserId && !message.parent_message_id)
-
+        .find((m) => m.sender_id === myUserId && !m.parent_message_id)
       if (lastEditableMessage) {
         event.preventDefault()
         setEditingMessage(lastEditableMessage)
@@ -415,21 +321,18 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       return
     }
 
-    // Escape to cancel reply
     if (event.key === 'Escape') {
-      if (trigger !== null) {
-        setTrigger(null)
-      } else if (replyingTo) {
-        setReplyingTo(null)
-      }
+      if (trigger !== null) setTrigger(null)
+      else if (replyingTo) setReplyingTo(null)
     }
   }
 
+  // --- Slate onChange ---
   const handleSlateChange = useCallback(() => {
     const markdown = serializeToMarkdown(editor.children)
     setContent(markdown)
     handleTyping()
-    updateAutocompleteState(markdown, markdown.length)
+    updateAutocompleteState()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, handleTyping])
 
@@ -439,24 +342,17 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
   }
 
   const handleDragEnter = (event: React.DragEvent<HTMLDivElement>): void => {
-    event.preventDefault()
-    event.stopPropagation()
-    dragDepthRef.current += 1
-    setDragActive(true)
+    event.preventDefault(); event.stopPropagation()
+    dragDepthRef.current += 1; setDragActive(true)
   }
-
   const handleDragLeave = (event: React.DragEvent<HTMLDivElement>): void => {
-    event.preventDefault()
-    event.stopPropagation()
+    event.preventDefault(); event.stopPropagation()
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
     if (dragDepthRef.current === 0) setDragActive(false)
   }
-
   const handleDrop = (event: React.DragEvent<HTMLDivElement>): void => {
-    event.preventDefault()
-    event.stopPropagation()
-    dragDepthRef.current = 0
-    setDragActive(false)
+    event.preventDefault(); event.stopPropagation()
+    dragDepthRef.current = 0; setDragActive(false)
     if (!uploading) stageFiles(Array.from(event.dataTransfer.files ?? []))
   }
 
@@ -473,7 +369,7 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         fileInputRef={fileInputRef}
         onAutocompleteHover={setSelectedAutocompleteIndex}
         onAutocompleteSelect={(item) => {
-          const index = autocompleteItems.findIndex((entry) => entry.id === item.id)
+          const index = autocompleteItems.findIndex((e) => e.id === item.id)
           commitAutocompleteSelection(index)
         }}
         onCancelReply={() => setReplyingTo(null)}
@@ -484,7 +380,6 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         onEmojiClose={() => setShowEmojiPicker(false)}
         onEmojiSelect={(emoji, item) => {
           const value = item?.type === 'custom' ? formatCustomEmojiToken(item as CustomEmoji) : emoji
-          // Insert emoji text at current cursor position in Slate
           Transforms.insertText(editor, value)
           setShowEmojiPicker(false)
         }}

--- a/client/src/renderer/src/components/chat/MessageInput.tsx
+++ b/client/src/renderer/src/components/chat/MessageInput.tsx
@@ -1,4 +1,6 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
+import { Slate } from 'slate-react'
+import { Editor, Transforms, Node } from 'slate'
 import { useServerStore } from '../../stores/serverStore'
 import { useDmStore } from '../../stores/dmStore'
 import { useMessageStore } from '../../stores/messageStore'
@@ -9,7 +11,6 @@ import { formatCustomEmojiToken, type CustomEmoji } from '../../utils/emoji'
 import { prepareMessageAttachment } from '../../utils/messageAttachment'
 import { getRendererEncryptedChat } from '../../sdk/client'
 import {
-  applyAutocompleteSelection,
   buildChannelSuggestions,
   buildEmojiSuggestions,
   buildMentionSuggestions,
@@ -19,10 +20,13 @@ import {
   type ComposerTriggerMatch
 } from './composerAutocompleteUtils'
 import type { Message } from '../../stores/messageStore'
+import { createVesperEditor } from './slate/createVesperEditor'
+import { serializeToMarkdown } from './slate/serialize'
+import { emptyDocument } from './slate/types'
+import VesperEditable from './slate/VesperEditable'
 
 let stagedIdCounter = 0
 const EMPTY_MESSAGES: Message[] = []
-const COMPOSER_MIN_HEIGHT = 56
 
 interface Props {
   scope: { kind: 'channel'; id: string } | { kind: 'dm'; id: string }
@@ -65,11 +69,20 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isTypingRef = useRef(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const previewRef = useRef<HTMLDivElement>(null)
   const emojiButtonRef = useRef<HTMLButtonElement>(null)
+  const editorContainerRef = useRef<HTMLDivElement>(null)
   const dragDepthRef = useRef(0)
   const [dragActive, setDragActive] = useState(false)
+
+  // Slate editor — stable across re-renders, reset on scope change
+  const editor = useMemo(() => {
+    const ed = createVesperEditor({ onSubmit: () => {} })
+    ed.children = emptyDocument()
+    return ed
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeId])
+
+  const slateValue = useMemo(() => emptyDocument(), [scopeId])
 
   const handleTyping = useCallback(() => {
     if (!isTypingRef.current) {
@@ -97,26 +110,19 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
 
   const stageFiles = useCallback((files: Iterable<File>): void => {
     const entries = Array.from(files)
-    if (entries.length === 0) {
-      return
-    }
+    if (entries.length === 0) return
 
     setStagedFiles((prev) => {
       const existingKeys = new Set(
         prev.map((entry) => `${entry.file.name}:${entry.file.size}:${entry.file.lastModified}`)
       )
       const next = [...prev]
-
       for (const file of entries) {
         const key = `${file.name}:${file.size}:${file.lastModified}`
-        if (existingKeys.has(key)) {
-          continue
-        }
-
+        if (existingKeys.has(key)) continue
         existingKeys.add(key)
         next.push({ file, id: `staged-${++stagedIdCounter}` })
       }
-
       return next
     })
   }, [])
@@ -138,8 +144,6 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
 
     const replyTo = useMessageStore.getState().replyingTo
     const parentId = replyTo?.id || undefined
-
-    // Resolve channelId for DM scopes so the SDK routes through the channel MLS path
     const resolvedScope = scope.kind === 'dm'
       ? { ...scope, channelId: conversations.find(c => c.id === scope.id)?.channel_id ?? undefined }
       : scope
@@ -180,14 +184,9 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     : []
 
   const commitAutocompleteSelection = (index: number): void => {
-    if (!trigger) {
-      return
-    }
-
+    if (!trigger) return
     const item = autocompleteItems[index]
-    if (!item) {
-      return
-    }
+    if (!item) return
 
     const replacement =
       item.type === 'user'
@@ -195,26 +194,65 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         : item.type === 'everyone'
           ? '@everyone'
           : item.value
-    const cursorPos = textareaRef.current?.selectionStart ?? content.length
-    const next = applyAutocompleteSelection(
-      content,
-      trigger.start,
-      cursorPos,
-      replacement,
-      item.type !== 'emoji'
+
+    // For Slate, we need to delete the trigger text and insert the replacement
+    // For now, use the content string approach (Phase 3 will use Slate void nodes)
+    const cursorPos = content.length
+    const start = content.lastIndexOf(
+      trigger.type === 'mention' ? '@' : trigger.type === 'channel' ? '#' : ':'
     )
-    setContent(next.value)
-    if (item.type === 'user' || item.type === 'everyone') {
-      setMentionDrafts((current) => [...current, { display: replacement, syntax: item.value }])
+    if (start >= 0) {
+      const before = content.slice(0, start)
+      const after = content.slice(cursorPos)
+      const newContent = before + replacement + ' ' + after
+
+      if (item.type === 'user' || item.type === 'everyone') {
+        setMentionDrafts((current) => [...current, { display: replacement, syntax: item.value }])
+      }
+
+      // Reset editor content
+      resetEditorContent(newContent)
     }
+
     setTrigger(null)
     setSelectedAutocompleteIndex(0)
+  }
 
-    requestAnimationFrame(() => {
-      textareaRef.current?.focus()
-      textareaRef.current?.setSelectionRange(next.caret, next.caret)
-      syncPreviewScroll()
+  const resetEditorContent = (text: string): void => {
+    // Clear editor and set new text
+    const point = { path: [0, 0], offset: 0 }
+    Transforms.delete(editor, {
+      at: { anchor: Editor.start(editor, []), focus: Editor.end(editor, []) }
     })
+    // Remove all nodes except first
+    while (editor.children.length > 1) {
+      Transforms.removeNodes(editor, { at: [editor.children.length - 1] })
+    }
+    // Set text of the remaining line
+    const firstChild = editor.children[0]
+    if (firstChild && 'children' in firstChild) {
+      Transforms.insertText(editor, text, { at: { path: [0, 0], offset: 0 } })
+    }
+    // Move cursor to end
+    Transforms.select(editor, Editor.end(editor, []))
+    setContent(text)
+  }
+
+  const clearEditor = (): void => {
+    Transforms.delete(editor, {
+      at: { anchor: Editor.start(editor, []), focus: Editor.end(editor, []) }
+    })
+    while (editor.children.length > 1) {
+      Transforms.removeNodes(editor, { at: [editor.children.length - 1] })
+    }
+    // Ensure the remaining node is a clean empty line
+    const remaining = editor.children[0]
+    if (remaining && 'children' in remaining && Node.string(remaining) !== '') {
+      Transforms.delete(editor, { at: [0] })
+      Transforms.insertNodes(editor, { type: 'line', children: [{ text: '' }] }, { at: [0] })
+    }
+    Transforms.select(editor, Editor.start(editor, []))
+    setContent('')
   }
 
   const updateAutocompleteState = (value: string, cursorPos: number): void => {
@@ -227,80 +265,38 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     setSelectedAutocompleteIndex(0)
   }
 
-  const syncPreviewScroll = (): void => {
-    if (!previewRef.current || !textareaRef.current) {
-      return
-    }
-
-    previewRef.current.scrollTop = textareaRef.current.scrollTop
-    previewRef.current.scrollLeft = textareaRef.current.scrollLeft
-  }
-
+  // Drag-and-drop handlers
   useEffect(() => {
-    if (!textareaRef.current) {
-      return
-    }
-
-    const maxHeight = Math.max(Math.round(window.innerHeight * 0.5), COMPOSER_MIN_HEIGHT)
-    textareaRef.current.style.height = '0px'
-    textareaRef.current.style.height = `${Math.min(
-      Math.max(textareaRef.current.scrollHeight, COMPOSER_MIN_HEIGHT),
-      maxHeight
-    )}px`
-    syncPreviewScroll()
-  }, [content])
-
-  useEffect(() => {
-    const hasFiles = (dataTransfer: DataTransfer | null): boolean =>
-      Boolean(dataTransfer?.types && Array.from(dataTransfer.types).includes('Files'))
+    const hasFiles = (dt: DataTransfer | null): boolean =>
+      Boolean(dt?.types && Array.from(dt.types).includes('Files'))
 
     const handleWindowDragEnter = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) {
-        return
-      }
-
+      if (!hasFiles(event.dataTransfer)) return
       event.preventDefault()
       dragDepthRef.current += 1
       setDragActive(true)
     }
 
     const handleWindowDragOver = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) {
-        return
-      }
-
+      if (!hasFiles(event.dataTransfer)) return
       event.preventDefault()
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'copy'
-      }
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
       setDragActive(true)
     }
 
     const handleWindowDragLeave = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) {
-        return
-      }
-
+      if (!hasFiles(event.dataTransfer)) return
       event.preventDefault()
       dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
-      if (dragDepthRef.current === 0) {
-        setDragActive(false)
-      }
+      if (dragDepthRef.current === 0) setDragActive(false)
     }
 
     const handleWindowDrop = (event: DragEvent): void => {
-      if (!hasFiles(event.dataTransfer)) {
-        return
-      }
-
+      if (!hasFiles(event.dataTransfer)) return
       event.preventDefault()
       dragDepthRef.current = 0
       setDragActive(false)
-
-      const files = Array.from(event.dataTransfer?.files ?? [])
-      if (!uploading) {
-        stageFiles(files)
-      }
+      if (!uploading) stageFiles(Array.from(event.dataTransfer?.files ?? []))
     }
 
     window.addEventListener('dragenter', handleWindowDragEnter)
@@ -316,10 +312,9 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     }
   }, [stageFiles, uploading])
 
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault()
-
-    const hasText = content.trim().length > 0
+  const handleSubmit = async (): Promise<void> => {
+    const markdown = serializeToMarkdown(editor.children).trim()
+    const hasText = markdown.length > 0
     const hasFiles = stagedFiles.length > 0
 
     if (!hasText && !hasFiles) return
@@ -328,7 +323,7 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       setUploading(true)
       try {
         for (let i = 0; i < stagedFiles.length; i++) {
-          const text = i === 0 ? content.trim() : undefined
+          const text = i === 0 ? markdown : undefined
           const serializedText = text ? serializeComposerMentions(text, mentionDrafts) : undefined
           const ok = await uploadAndSendFile(stagedFiles[i].file, serializedText)
           if (!ok) {
@@ -337,7 +332,7 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
           }
         }
         setStagedFiles([])
-        setContent('')
+        clearEditor()
         setMentionDrafts([])
         useMessageStore.getState().setReplyingTo(null)
       } catch {
@@ -347,83 +342,81 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       }
     } else {
       const send = isChannel ? sendMessage : sendDmMessage
-      send(scopeId, serializeComposerMentions(content.trim(), mentionDrafts))
-      setContent('')
+      send(scopeId, serializeComposerMentions(markdown, mentionDrafts))
+      clearEditor()
       setMentionDrafts([])
     }
 
     setTrigger(null)
     setSelectedAutocompleteIndex(0)
 
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current)
-    }
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current)
     if (isTypingRef.current) {
       isTypingRef.current = false
-      if (isChannel) {
-        sendTypingStop(scopeId)
-      } else {
-        sendDmTypingStop(scopeId)
-      }
+      if (isChannel) sendTypingStop(scopeId)
+      else sendDmTypingStop(scopeId)
     }
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent): void => {
+  const handleKeyDown = (event: React.KeyboardEvent): void => {
+    // Autocomplete navigation
     if (trigger && autocompleteItems.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
         setSelectedAutocompleteIndex((current) => (current + 1) % autocompleteItems.length)
         return
       }
-
-      if (e.key === 'ArrowUp') {
-        e.preventDefault()
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
         setSelectedAutocompleteIndex((current) =>
           current <= 0 ? autocompleteItems.length - 1 : current - 1
         )
         return
       }
-
-      if (e.key === 'Enter' || e.key === 'Tab') {
-        e.preventDefault()
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault()
         commitAutocompleteSelection(selectedAutocompleteIndex)
         return
       }
-
-      if (e.key === 'Escape') {
-        e.preventDefault()
+      if (event.key === 'Escape') {
+        event.preventDefault()
         setTrigger(null)
         return
       }
     }
 
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      void handleSubmit(e)
+    // Submit on Enter (not Shift+Enter)
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      void handleSubmit()
+      return
     }
+
+    // Edit last message on ArrowUp in empty editor
     if (
-      e.key === 'ArrowUp' &&
-      !e.shiftKey &&
-      !e.altKey &&
-      !e.metaKey &&
-      !e.ctrlKey &&
+      event.key === 'ArrowUp' &&
+      !event.shiftKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      !event.ctrlKey &&
       !content &&
       stagedFiles.length === 0 &&
       !replyingTo &&
-      !uploading &&
-      textareaRef.current?.selectionStart === 0
+      !uploading
     ) {
       const lastEditableMessage = [...messages]
         .reverse()
         .find((message) => message.sender_id === myUserId && !message.parent_message_id)
 
       if (lastEditableMessage) {
-        e.preventDefault()
+        event.preventDefault()
         setEditingMessage(lastEditableMessage)
       }
       return
     }
-    if (e.key === 'Escape') {
+
+    // Escape to cancel reply
+    if (event.key === 'Escape') {
       if (trigger !== null) {
         setTrigger(null)
       } else if (replyingTo) {
@@ -432,106 +425,88 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
     }
   }
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-    const value = e.target.value
-    setContent(value)
+  const handleSlateChange = useCallback(() => {
+    const markdown = serializeToMarkdown(editor.children)
+    setContent(markdown)
     handleTyping()
-    updateAutocompleteState(value, e.target.selectionStart)
-    syncPreviewScroll()
-  }
+    updateAutocompleteState(markdown, markdown.length)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, handleTyping])
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>): void => {
     stageFiles(Array.from(e.target.files ?? []))
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ''
-    }
-
-    textareaRef.current?.focus()
+    if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
-  const handleDragEnter = (event: React.DragEvent<HTMLFormElement>): void => {
+  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault()
     event.stopPropagation()
     dragDepthRef.current += 1
     setDragActive(true)
   }
 
-  const handleDragLeave = (event: React.DragEvent<HTMLFormElement>): void => {
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault()
     event.stopPropagation()
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
-    if (dragDepthRef.current === 0) {
-      setDragActive(false)
-    }
+    if (dragDepthRef.current === 0) setDragActive(false)
   }
 
-  const handleDrop = (event: React.DragEvent<HTMLFormElement>): void => {
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault()
     event.stopPropagation()
     dragDepthRef.current = 0
     setDragActive(false)
-
-    if (!uploading) {
-      stageFiles(Array.from(event.dataTransfer.files ?? []))
-    }
+    if (!uploading) stageFiles(Array.from(event.dataTransfer.files ?? []))
   }
 
   const canSend = content.trim().length > 0 || stagedFiles.length > 0
 
   return (
-    <ComposerForm
-      autocompleteItems={autocompleteItems}
-      content={content}
-      conversation={activeConversation ?? undefined}
-      dragActive={dragActive}
-      emojiButtonRef={emojiButtonRef}
-      encryptionError={encryptionError}
-      fileInputRef={fileInputRef}
-      members={members}
-      mentionDrafts={mentionDrafts}
-      onAutocompleteHover={setSelectedAutocompleteIndex}
-      onAutocompleteSelect={(item) => {
-        const index = autocompleteItems.findIndex((entry) => entry.id === item.id)
-        commitAutocompleteSelection(index)
-      }}
-      onCancelReply={() => setReplyingTo(null)}
-      onClearEncryptionError={() => useMessageStore.setState({ encryptionError: null })}
-      onDragEnter={handleDragEnter}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-      onEmojiClose={() => setShowEmojiPicker(false)}
-      onEmojiSelect={(emoji, item) => {
-        const value = item?.type === 'custom' ? formatCustomEmojiToken(item as CustomEmoji) : emoji
-        setContent((prev) => prev + value)
-        setShowEmojiPicker(false)
-        requestAnimationFrame(() => {
-          textareaRef.current?.focus()
-          syncPreviewScroll()
-        })
-      }}
-      onFileSelect={handleFileSelect}
-      onRemoveStagedFile={removeStagedFile}
-      onSubmit={(event) => { void handleSubmit(event) }}
-      onTextareaChange={handleChange}
-      onTextareaClick={(event) => updateAutocompleteState(event.currentTarget.value, event.currentTarget.selectionStart)}
-      onTextareaKeyDown={handleKeyDown}
-      onTextareaKeyUp={(event) => updateAutocompleteState(event.currentTarget.value, event.currentTarget.selectionStart)}
-      onTextareaScroll={syncPreviewScroll}
-      onToggleEmojiPicker={() => setShowEmojiPicker(!showEmojiPicker)}
-      placeholder={isChannel ? 'Message this channel' : 'Message this conversation'}
-      previewRef={previewRef}
-      replyingTo={replyingTo}
-      selectedAutocompleteIndex={selectedAutocompleteIndex}
-      sendButtonTestId={isChannel ? 'send-button' : undefined}
-      server={activeServer}
-      showEmojiPicker={showEmojiPicker}
-      stagedFiles={stagedFiles}
-      textareaRef={textareaRef}
-      textareaTestId={isChannel ? 'message-input' : undefined}
-      triggerQuery={trigger?.query ?? null}
-      uploading={uploading}
-      canSend={canSend}
-    />
+    <Slate editor={editor} initialValue={slateValue} onChange={handleSlateChange}>
+      <ComposerForm
+        autocompleteItems={autocompleteItems}
+        dragActive={dragActive}
+        editorContainerRef={editorContainerRef}
+        emojiButtonRef={emojiButtonRef}
+        encryptionError={encryptionError}
+        fileInputRef={fileInputRef}
+        onAutocompleteHover={setSelectedAutocompleteIndex}
+        onAutocompleteSelect={(item) => {
+          const index = autocompleteItems.findIndex((entry) => entry.id === item.id)
+          commitAutocompleteSelection(index)
+        }}
+        onCancelReply={() => setReplyingTo(null)}
+        onClearEncryptionError={() => useMessageStore.setState({ encryptionError: null })}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onEmojiClose={() => setShowEmojiPicker(false)}
+        onEmojiSelect={(emoji, item) => {
+          const value = item?.type === 'custom' ? formatCustomEmojiToken(item as CustomEmoji) : emoji
+          // Insert emoji text at current cursor position in Slate
+          Transforms.insertText(editor, value)
+          setShowEmojiPicker(false)
+        }}
+        onFileSelect={handleFileSelect}
+        onRemoveStagedFile={removeStagedFile}
+        onSend={() => { void handleSubmit() }}
+        onToggleEmojiPicker={() => setShowEmojiPicker(!showEmojiPicker)}
+        replyingTo={replyingTo}
+        selectedAutocompleteIndex={selectedAutocompleteIndex}
+        sendButtonTestId={isChannel ? 'send-button' : undefined}
+        showEmojiPicker={showEmojiPicker}
+        stagedFiles={stagedFiles}
+        triggerQuery={trigger?.query ?? null}
+        uploading={uploading}
+        canSend={canSend}
+      >
+        <VesperEditable
+          placeholder={isChannel ? 'Message this channel' : 'Message this conversation'}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+      </ComposerForm>
+    </Slate>
   )
 }

--- a/client/src/renderer/src/components/chat/MessageInput.tsx
+++ b/client/src/renderer/src/components/chat/MessageInput.tsx
@@ -7,6 +7,7 @@ import { useMessageStore } from '../../stores/messageStore'
 import { useAuthStore } from '../../stores/authStore'
 import ComposerForm from './ComposerForm'
 import type { StagedFile } from './message/ComposerShell'
+import { resolveFilename } from './message/ComposerShell'
 import { formatCustomEmojiToken, type CustomEmoji } from '../../utils/emoji'
 import { prepareMessageAttachment } from '../../utils/messageAttachment'
 import { getRendererEncryptedChat } from '../../sdk/client'
@@ -61,6 +62,14 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
   )
   const activeServer = servers.find((server) => server.id === activeServerId)
   const activeConversation = isChannel ? undefined : conversations.find((c) => c.id === scopeId)
+  const fetchMembers = useServerStore((s) => s.fetchMembers)
+
+  // Ensure members are loaded for @mention autocomplete
+  useEffect(() => {
+    if (isChannel && activeServerId && members.length === 0) {
+      void fetchMembers(activeServerId)
+    }
+  }, [isChannel, activeServerId, members.length, fetchMembers])
 
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isTypingRef = useRef(false)
@@ -117,6 +126,18 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
 
   const removeStagedFile = (id: string): void => {
     setStagedFiles((prev) => prev.filter((e) => e.id !== id))
+  }
+
+  const toggleStagedFileSpoiler = (id: string): void => {
+    setStagedFiles((prev) =>
+      prev.map((e) => e.id === id ? { ...e, spoiler: !e.spoiler } : e)
+    )
+  }
+
+  const toggleStagedFileAnonymous = (id: string): void => {
+    setStagedFiles((prev) =>
+      prev.map((e) => e.id === id ? { ...e, anonymous: !e.anonymous } : e)
+    )
   }
 
   const uploadAndSendFile = async (file: File, text: string | undefined): Promise<boolean> => {
@@ -248,7 +269,12 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
       try {
         for (let i = 0; i < stagedFiles.length; i++) {
           const text = i === 0 ? markdown : undefined
-          const ok = await uploadAndSendFile(stagedFiles[i].file, text)
+          const entry = stagedFiles[i]
+          const finalName = resolveFilename(entry)
+          const renamedFile = finalName !== entry.file.name
+            ? new File([entry.file], finalName, { type: entry.file.type })
+            : entry.file
+          const ok = await uploadAndSendFile(renamedFile, text)
           if (!ok) { setUploading(false); return }
         }
         setStagedFiles([])
@@ -379,12 +405,40 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         onDrop={handleDrop}
         onEmojiClose={() => setShowEmojiPicker(false)}
         onEmojiSelect={(emoji, item) => {
-          const value = item?.type === 'custom' ? formatCustomEmojiToken(item as CustomEmoji) : emoji
-          Transforms.insertText(editor, value)
+          // Ensure editor has focus and valid selection
+          if (!editor.selection) {
+            Transforms.select(editor, Editor.end(editor, []))
+          }
+          if (item?.type === 'custom') {
+            const ce = item as CustomEmoji
+            Transforms.insertNodes(editor, [
+              {
+                type: 'custom-emoji' as const,
+                token: formatCustomEmojiToken(ce),
+                name: ce.name,
+                url: ce.url,
+                animated: ce.animated ?? false,
+                children: [{ text: '' }],
+              },
+              { text: ' ' },
+            ], { at: editor.selection!, select: true })
+          } else {
+            Transforms.insertNodes(editor, [
+              {
+                type: 'emoji' as const,
+                unicode: emoji,
+                children: [{ text: '' }],
+              },
+              { text: ' ' },
+            ], { at: editor.selection!, select: true })
+          }
+          Transforms.move(editor, { distance: 1 })
           setShowEmojiPicker(false)
         }}
         onFileSelect={handleFileSelect}
         onRemoveStagedFile={removeStagedFile}
+        onToggleStagedFileSpoiler={toggleStagedFileSpoiler}
+        onToggleStagedFileAnonymous={toggleStagedFileAnonymous}
         onSend={() => { void handleSubmit() }}
         onToggleEmojiPicker={() => setShowEmojiPicker(!showEmojiPicker)}
         replyingTo={replyingTo}

--- a/client/src/renderer/src/components/chat/MessageInput.tsx
+++ b/client/src/renderer/src/components/chat/MessageInput.tsx
@@ -5,11 +5,13 @@ import { useServerStore } from '../../stores/serverStore'
 import { useDmStore } from '../../stores/dmStore'
 import { useMessageStore } from '../../stores/messageStore'
 import { useAuthStore } from '../../stores/authStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import ComposerForm from './ComposerForm'
 import type { StagedFile } from './message/ComposerShell'
 import { resolveFilename } from './message/ComposerShell'
 import { formatCustomEmojiToken, type CustomEmoji } from '../../utils/emoji'
 import { prepareMessageAttachment } from '../../utils/messageAttachment'
+import { stripExifData } from '../../utils/stripExif'
 import { getRendererEncryptedChat } from '../../sdk/client'
 import {
   buildChannelSuggestions,
@@ -270,11 +272,21 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         for (let i = 0; i < stagedFiles.length; i++) {
           const text = i === 0 ? markdown : undefined
           const entry = stagedFiles[i]
-          const finalName = resolveFilename(entry)
-          const renamedFile = finalName !== entry.file.name
+          // Apply global privacy settings
+          const privacySettings = useSettingsStore.getState()
+          const effectiveEntry = {
+            ...entry,
+            anonymous: entry.anonymous || privacySettings.anonFilenames,
+          }
+          const finalName = resolveFilename(effectiveEntry)
+          let fileToSend = finalName !== entry.file.name
             ? new File([entry.file], finalName, { type: entry.file.type })
             : entry.file
-          const ok = await uploadAndSendFile(renamedFile, text)
+          // Strip EXIF from images if enabled
+          if (privacySettings.stripExif && fileToSend.type.startsWith('image/')) {
+            fileToSend = await stripExifData(fileToSend)
+          }
+          const ok = await uploadAndSendFile(fileToSend, text)
           if (!ok) { setUploading(false); return }
         }
         setStagedFiles([])
@@ -453,6 +465,7 @@ export default function MessageInput({ scope }: Props): React.JSX.Element {
         <VesperEditable
           placeholder={isChannel ? 'Message this channel' : 'Message this conversation'}
           onKeyDown={handleKeyDown}
+          onPasteAsFile={(file) => stageFiles([file])}
           autoFocus
         />
       </ComposerForm>

--- a/client/src/renderer/src/components/chat/MessageItem.tsx
+++ b/client/src/renderer/src/components/chat/MessageItem.tsx
@@ -1,4 +1,4 @@
-import { memo, Suspense, useState, useRef, useEffect, useMemo } from 'react'
+import { memo, Suspense, useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { Copy, Lock, MessageSquare, Pencil, Pin, Reply, Trash2 } from 'lucide-react'
 import type { Message } from '../../stores/messageStore'
 import { useMessageStore, parseMessageContent } from '../../stores/messageStore'
@@ -19,6 +19,7 @@ import MessageReactionBar from './message/MessageReactionBar'
 import ProfilePopout from '../profile/ProfilePopout'
 import { formatCustomEmojiToken, type CustomEmoji } from '../../utils/emoji'
 import lazyWithRetry from '../../utils/lazyWithRetry'
+import VesperEditor from './slate/VesperEditor'
 
 const MarkdownContent = lazyWithRetry(() => import('./MarkdownContent'))
 const EMPTY_EMOJIS: CustomEmoji[] = []
@@ -170,8 +171,6 @@ export default memo(function MessageItem({
   isThreadView = false
 }: Props): React.JSX.Element {
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
-  const [editText, setEditText] = useState('')
-  const editRef = useRef<HTMLTextAreaElement>(null)
   const reactionAnchorRef = useRef<HTMLDivElement>(null)
   const membersByUserId = useServerStore((s) => s.membersByUserId)
   const liveMember = membersByUserId.get(message.sender_id ?? '')
@@ -223,35 +222,18 @@ export default memo(function MessageItem({
     [message.content]
   )
 
-  useEffect(() => {
-    if (isEditing && editRef.current) {
-      editRef.current.focus()
-      editRef.current.selectionStart = editRef.current.value.length
-    }
-  }, [isEditing])
-
   const handleStartEdit = (): void => {
-    setEditText(message.content)
     setEditingMessage(message)
   }
 
-  const handleSaveEdit = (): void => {
-    const trimmed = editText.trim()
+  const handleSaveEdit = useCallback((markdown: string): void => {
+    const trimmed = markdown.trim()
     if (trimmed && trimmed !== message.content) {
       editMessage(targetId, topic, message.id, trimmed)
     } else {
       setEditingMessage(null)
     }
-  }
-
-  const handleEditKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSaveEdit()
-    } else if (e.key === 'Escape') {
-      setEditingMessage(null)
-    }
-  }
+  }, [editMessage, message.content, message.id, setEditingMessage, targetId, topic])
 
   const handleDelete = (): void => {
     deleteMessage(targetId, topic, message.id)
@@ -488,15 +470,16 @@ export default memo(function MessageItem({
 
         {isEditing ? (
           <div className="mt-1">
-            <textarea
-              data-testid="edit-input"
-              ref={editRef}
-              value={editText}
-              onChange={(e) => setEditText(e.target.value)}
-              onKeyDown={handleEditKeyDown}
-              className="w-full rounded-xl border border-border bg-bg-secondary/70 px-3 py-2 text-sm text-text-secondary focus:border-accent/50 focus:outline-none resize-none"
-              rows={Math.min(editText.split('\n').length + 1, 6)}
-            />
+            <div className="rounded-xl border border-border bg-bg-secondary/70 px-3 py-2 text-sm text-text-secondary focus-within:border-accent/50">
+              <VesperEditor
+                mode="edit"
+                initialValue={message.content}
+                onSubmit={handleSaveEdit}
+                onCancel={() => setEditingMessage(null)}
+                placeholder="Edit message..."
+                autoFocus
+              />
+            </div>
             <p className="mt-1 text-xs text-text-faintest">
               Enter to save · Escape to cancel
             </p>

--- a/client/src/renderer/src/components/chat/MessageItem.tsx
+++ b/client/src/renderer/src/components/chat/MessageItem.tsx
@@ -176,10 +176,10 @@ export default memo(function MessageItem({
   const liveMember = membersByUserId.get(message.sender_id ?? '')
   const myUser = useAuthStore((s) => s.user)
   const myId = myUser?.id
-  const customEmojis = useServerStore((s) => {
-    const srv = s.servers.find((server) => server.id === s.activeServerId)
-    return srv?.emojis ?? EMPTY_EMOJIS
-  })
+  const activeServer = useServerStore((s) =>
+    s.servers.find((server) => server.id === s.activeServerId)
+  )
+  const customEmojis = activeServer?.emojis ?? EMPTY_EMOJIS
   const isMe = message.sender_id === myId
   const displayName = isMe
     ? (myUser?.display_name || myUser?.username || 'Unknown')

--- a/client/src/renderer/src/components/chat/message/ComposerShell.tsx
+++ b/client/src/renderer/src/components/chat/message/ComposerShell.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from 'react'
-import { FileIcon, X } from 'lucide-react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { Eye, EyeOff, Glasses, Trash2, FileIcon, X } from 'lucide-react'
 import { parseMessageContent, type Message } from '../../../stores/messageStore'
 
 export interface StagedFile {
   file: File
   id: string
+  spoiler?: boolean
+  anonymous?: boolean
 }
 
 interface Props {
@@ -14,27 +16,156 @@ interface Props {
   onCancelReply: () => void
   stagedFiles?: StagedFile[]
   onRemoveStagedFile?: (id: string) => void
+  onToggleSpoiler?: (id: string) => void
+  onToggleAnonymous?: (id: string) => void
   children: ReactNode
+}
+
+function generateAnonFilename(originalName: string): string {
+  const ext = originalName.includes('.') ? originalName.slice(originalName.lastIndexOf('.')) : ''
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
+  let name = ''
+  for (let i = 0; i < 16; i++) {
+    name += chars[Math.floor(Math.random() * chars.length)]
+  }
+  return name + ext
+}
+
+export function resolveFilename(entry: StagedFile): string {
+  let name = entry.anonymous ? generateAnonFilename(entry.file.name) : entry.file.name
+  if (entry.spoiler && !name.startsWith('SPOILER_')) {
+    name = 'SPOILER_' + name
+  }
+  return name
 }
 
 function getReplyAuthor(message: Message): string {
   return message.sender?.display_name || message.sender?.username || 'Unknown'
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
-
 function getReplyPreview(message: Message): string {
   const parsed = parseMessageContent(message.content || '')
-
   if (parsed.type === 'file') {
     return parsed.text || parsed.file.name || 'Sent a file'
   }
-
   return parsed.text || ''
+}
+
+function isImageFile(file: File): boolean {
+  return file.type.startsWith('image/')
+}
+
+function isVideoFile(file: File): boolean {
+  return file.type.startsWith('video/')
+}
+
+function StagedFileCard({
+  entry,
+  onRemove,
+  onToggleSpoiler,
+  onToggleAnonymous,
+}: {
+  entry: StagedFile
+  onRemove: () => void
+  onToggleSpoiler?: () => void
+  onToggleAnonymous?: () => void
+}): React.JSX.Element {
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isImageFile(entry.file)) {
+      const url = URL.createObjectURL(entry.file)
+      setThumbnailUrl(url)
+      return () => URL.revokeObjectURL(url)
+    }
+    if (isVideoFile(entry.file)) {
+      const url = URL.createObjectURL(entry.file)
+      const video = document.createElement('video')
+      video.preload = 'metadata'
+      video.muted = true
+      video.src = url
+      video.currentTime = 1
+      video.onloadeddata = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.min(video.videoWidth, 320)
+        canvas.height = Math.round(canvas.width * (video.videoHeight / video.videoWidth))
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+          setThumbnailUrl(canvas.toDataURL('image/jpeg', 0.7))
+        }
+        URL.revokeObjectURL(url)
+      }
+      video.onerror = () => URL.revokeObjectURL(url)
+      return () => {
+        video.src = ''
+        URL.revokeObjectURL(url)
+      }
+    }
+    return undefined
+  }, [entry.file])
+
+  const displayName = resolveFilename(entry)
+  const truncatedName = displayName.length > 24
+    ? displayName.slice(0, 21) + '...'
+    : displayName
+
+  return (
+    <div className={`vesper-staged-card${entry.anonymous ? ' vesper-staged-card-anon' : ''}`} data-testid="staged-file">
+      <div className="vesper-staged-card-actions">
+        {onToggleAnonymous && (
+          <button
+            type="button"
+            onClick={onToggleAnonymous}
+            className={`vesper-staged-card-action${entry.anonymous ? ' vesper-staged-card-action-active' : ''}`}
+            title={entry.anonymous ? 'Use original filename' : 'Anonymize filename'}
+          >
+            <Glasses className="w-3.5 h-3.5" />
+          </button>
+        )}
+        {onToggleSpoiler && (
+          <button
+            type="button"
+            onClick={onToggleSpoiler}
+            className={`vesper-staged-card-action${entry.spoiler ? ' vesper-staged-card-action-active' : ''}`}
+            title={entry.spoiler ? 'Remove spoiler' : 'Mark as spoiler'}
+          >
+            {entry.spoiler ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="vesper-staged-card-action vesper-staged-card-action-delete"
+          aria-label={`Remove ${entry.file.name}`}
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className={`vesper-staged-card-preview${entry.spoiler ? ' vesper-staged-card-spoiler' : ''}`}>
+        {thumbnailUrl ? (
+          <img
+            src={thumbnailUrl}
+            alt={entry.file.name}
+            className="vesper-staged-card-thumbnail"
+            draggable={false}
+          />
+        ) : (
+          <div className="vesper-staged-card-icon">
+            <FileIcon className="w-10 h-10" />
+          </div>
+        )}
+        {entry.spoiler && (
+          <div className="vesper-staged-card-spoiler-label">SPOILER</div>
+        )}
+      </div>
+
+      <div className="vesper-staged-card-name" title={entry.file.name}>
+        {truncatedName}
+      </div>
+    </div>
+  )
 }
 
 export default function ComposerShell({
@@ -44,6 +175,8 @@ export default function ComposerShell({
   onCancelReply,
   stagedFiles,
   onRemoveStagedFile,
+  onToggleSpoiler,
+  onToggleAnonymous,
   children
 }: Props): React.JSX.Element {
   const hasStaged = stagedFiles && stagedFiles.length > 0
@@ -67,25 +200,15 @@ export default function ComposerShell({
 
       <div className={hasTopContent ? 'vesper-composer vesper-composer-has-reply' : 'vesper-composer'}>
         {hasStaged && (
-          <div className="vesper-composer-staged-files">
+          <div className="vesper-staged-tray">
             {stagedFiles.map((entry) => (
-              <div key={entry.id} className="vesper-composer-staged-file" data-testid="staged-file">
-                <FileIcon className="w-4 h-4 shrink-0 text-accent" />
-                <span className="vesper-composer-staged-name" title={entry.file.name}>
-                  {entry.file.name}
-                </span>
-                <span className="vesper-composer-staged-size">
-                  {formatFileSize(entry.file.size)}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => onRemoveStagedFile?.(entry.id)}
-                  className="vesper-composer-staged-remove"
-                  aria-label={`Remove ${entry.file.name}`}
-                >
-                  <X className="w-3.5 h-3.5" />
-                </button>
-              </div>
+              <StagedFileCard
+                key={entry.id}
+                entry={entry}
+                onRemove={() => onRemoveStagedFile?.(entry.id)}
+                onToggleSpoiler={onToggleSpoiler ? () => onToggleSpoiler(entry.id) : undefined}
+                onToggleAnonymous={onToggleAnonymous ? () => onToggleAnonymous(entry.id) : undefined}
+              />
             ))}
           </div>
         )}

--- a/client/src/renderer/src/components/chat/message/SpoilerReveal.tsx
+++ b/client/src/renderer/src/components/chat/message/SpoilerReveal.tsx
@@ -1,0 +1,35 @@
+import { useState, useCallback } from 'react'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export default function SpoilerReveal({ children }: Props): React.JSX.Element {
+  const [revealed, setRevealed] = useState(false)
+
+  const handleClick = useCallback(() => {
+    setRevealed((prev) => !prev)
+  }, [])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      setRevealed((prev) => !prev)
+    }
+  }, [])
+
+  return (
+    <span
+      className={revealed ? 'vesper-spoiler vesper-spoiler-revealed' : 'vesper-spoiler vesper-spoiler-hidden'}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={revealed ? 'Spoiler revealed' : 'Spoiler — click to reveal'}
+    >
+      <span className="vesper-spoiler-content">
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
-import { Editable, type RenderElementProps, type RenderLeafProps } from 'slate-react'
-import type { NodeEntry } from 'slate'
+import { Editable, useSlateStatic, type RenderElementProps, type RenderLeafProps } from 'slate-react'
+import { Editor, Transforms, type NodeEntry } from 'slate'
 import LineElement from './elements/LineElement'
 import BlockQuoteElement from './elements/BlockQuoteElement'
 import CodeBlockElement from './elements/CodeBlockElement'
@@ -31,6 +31,53 @@ export default function VesperEditable({
   readOnly = false,
   autoFocus = false,
 }: Props): React.JSX.Element {
+  const editor = useSlateStatic()
+
+  // When clicking in the empty space of the editor (past the text),
+  // place the cursor at the end of the line. Slate's default behavior
+  // resolves clicks in empty space to offset 0 (start of line),
+  // especially after inline void nodes (emoji).
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement
+      const editable = event.currentTarget
+
+      // Only intercept clicks directly on a line div or the editable itself
+      const isLineDiv = target.getAttribute('data-slate-node') === 'element' && target.parentElement === editable
+      const isEditable = target === editable
+
+      if (!isLineDiv && !isEditable) return
+
+      // Don't intercept if the editor has no real content — let Slate focus normally
+      const docText = Editor.string(editor, [])
+      const hasVoids = Array.from(Editor.nodes(editor, {
+        at: [],
+        match: n => editor.isVoid(n as any),
+      })).length > 0
+      if (!docText && !hasVoids) return
+
+      const clickY = event.clientY
+      const lines = editable.querySelectorAll<HTMLElement>(':scope > [data-slate-node="element"]')
+
+      for (let i = 0; i < lines.length; i++) {
+        const rect = lines[i].getBoundingClientRect()
+        if (clickY >= rect.top && clickY <= rect.bottom) {
+          event.preventDefault()
+          Transforms.select(editor, Editor.end(editor, [i]))
+          // Ensure focus since we prevented default
+          editable.focus()
+          return
+        }
+      }
+
+      if (isEditable) {
+        event.preventDefault()
+        Transforms.select(editor, Editor.end(editor, []))
+        editable.focus()
+      }
+    },
+    [editor]
+  )
   const renderElement = useCallback(
     (props: RenderElementProps) => {
       switch (props.element.type) {
@@ -73,6 +120,7 @@ export default function VesperEditable({
       renderLeaf={renderLeaf}
       decorate={decorate}
       placeholder={placeholder}
+      onMouseDown={handleMouseDown}
       onKeyDown={onKeyDown}
       readOnly={readOnly}
       autoFocus={autoFocus}

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -1,7 +1,9 @@
 import { useCallback } from 'react'
 import { Editable, type RenderElementProps, type RenderLeafProps } from 'slate-react'
+import type { NodeEntry } from 'slate'
 import LineElement from './elements/LineElement'
 import FormattedLeaf from './leaves/FormattedLeaf'
+import { decorateMarkdown } from './decorations'
 
 interface Props {
   placeholder?: string
@@ -35,11 +37,17 @@ export default function VesperEditable({
     []
   )
 
+  const decorate = useCallback(
+    (entry: NodeEntry) => decorateMarkdown(entry),
+    []
+  )
+
   return (
     <Editable
       className="vesper-slate-editable"
       renderElement={renderElement}
       renderLeaf={renderLeaf}
+      decorate={decorate}
       placeholder={placeholder}
       onKeyDown={onKeyDown}
       readOnly={readOnly}

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -1,0 +1,51 @@
+import { useCallback } from 'react'
+import { Editable, type RenderElementProps, type RenderLeafProps } from 'slate-react'
+import LineElement from './elements/LineElement'
+import FormattedLeaf from './leaves/FormattedLeaf'
+
+interface Props {
+  placeholder?: string
+  onKeyDown?: (event: React.KeyboardEvent) => void
+  readOnly?: boolean
+  autoFocus?: boolean
+}
+
+export default function VesperEditable({
+  placeholder = 'Type a message...',
+  onKeyDown,
+  readOnly = false,
+  autoFocus = false,
+}: Props): React.JSX.Element {
+  const renderElement = useCallback(
+    (props: RenderElementProps) => {
+      switch (props.element.type) {
+        case 'line':
+          return <LineElement {...props} />
+        // Phase 4: blockquote, code-block, code-block-line
+        // Phase 3: emoji, custom-emoji, user-mention, channel-mention
+        default:
+          return <LineElement {...props} />
+      }
+    },
+    []
+  )
+
+  const renderLeaf = useCallback(
+    (props: RenderLeafProps) => <FormattedLeaf {...props} />,
+    []
+  )
+
+  return (
+    <Editable
+      className="vesper-slate-editable"
+      renderElement={renderElement}
+      renderLeaf={renderLeaf}
+      placeholder={placeholder}
+      onKeyDown={onKeyDown}
+      readOnly={readOnly}
+      autoFocus={autoFocus}
+      spellCheck
+      data-testid="message-input"
+    />
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import { Editable, useSlateStatic, type RenderElementProps, type RenderLeafProps } from 'slate-react'
 import { Editor, Transforms, type NodeEntry } from 'slate'
 import LineElement from './elements/LineElement'
-import BlockQuoteElement from './elements/BlockQuoteElement'
 import CodeBlockElement from './elements/CodeBlockElement'
 import EmojiVoid from './elements/EmojiVoid'
 import CustomEmojiVoid from './elements/CustomEmojiVoid'
@@ -18,9 +17,12 @@ import type {
   CodeBlockElement as CodeBlockElementType,
 } from './types'
 
+const PASTE_AS_FILE_THRESHOLD = 2000
+
 interface Props {
   placeholder?: string
   onKeyDown?: (event: React.KeyboardEvent) => void
+  onPasteAsFile?: (file: File) => void
   readOnly?: boolean
   autoFocus?: boolean
 }
@@ -28,6 +30,7 @@ interface Props {
 export default function VesperEditable({
   placeholder = 'Type a message...',
   onKeyDown,
+  onPasteAsFile,
   readOnly = false,
   autoFocus = false,
 }: Props): React.JSX.Element {
@@ -89,8 +92,6 @@ export default function VesperEditable({
           return <UserMentionVoid {...props} element={props.element as UserMentionElement} />
         case 'channel-mention':
           return <ChannelMentionVoid {...props} element={props.element as ChannelMentionElement} />
-        case 'blockquote':
-          return <BlockQuoteElement {...props} />
         case 'code-block':
           return <CodeBlockElement {...props} element={props.element as CodeBlockElementType} />
         case 'code-block-line':
@@ -113,6 +114,20 @@ export default function VesperEditable({
     []
   )
 
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const text = event.clipboardData.getData('text/plain')
+      if (text && text.length > PASTE_AS_FILE_THRESHOLD && onPasteAsFile) {
+        event.preventDefault()
+        const blob = new Blob([text], { type: 'text/plain' })
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+        const file = new File([blob], `paste-${timestamp}.txt`, { type: 'text/plain' })
+        onPasteAsFile(file)
+      }
+    },
+    [onPasteAsFile]
+  )
+
   return (
     <Editable
       className="vesper-slate-editable"
@@ -121,6 +136,7 @@ export default function VesperEditable({
       decorate={decorate}
       placeholder={placeholder}
       onMouseDown={handleMouseDown}
+      onPaste={handlePaste}
       onKeyDown={onKeyDown}
       readOnly={readOnly}
       autoFocus={autoFocus}

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 import { Editable, type RenderElementProps, type RenderLeafProps } from 'slate-react'
 import type { NodeEntry } from 'slate'
 import LineElement from './elements/LineElement'
+import BlockQuoteElement from './elements/BlockQuoteElement'
+import CodeBlockElement from './elements/CodeBlockElement'
 import EmojiVoid from './elements/EmojiVoid'
 import CustomEmojiVoid from './elements/CustomEmojiVoid'
 import UserMentionVoid from './elements/UserMentionVoid'
@@ -13,6 +15,7 @@ import type {
   CustomEmojiElement,
   UserMentionElement,
   ChannelMentionElement,
+  CodeBlockElement as CodeBlockElementType,
 } from './types'
 
 interface Props {
@@ -39,6 +42,12 @@ export default function VesperEditable({
           return <UserMentionVoid {...props} element={props.element as UserMentionElement} />
         case 'channel-mention':
           return <ChannelMentionVoid {...props} element={props.element as ChannelMentionElement} />
+        case 'blockquote':
+          return <BlockQuoteElement {...props} />
+        case 'code-block':
+          return <CodeBlockElement {...props} element={props.element as CodeBlockElementType} />
+        case 'code-block-line':
+          return <div {...props.attributes} className="vesper-slate-code-line">{props.children}</div>
         case 'line':
         default:
           return <LineElement {...props} />

--- a/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditable.tsx
@@ -2,8 +2,18 @@ import { useCallback } from 'react'
 import { Editable, type RenderElementProps, type RenderLeafProps } from 'slate-react'
 import type { NodeEntry } from 'slate'
 import LineElement from './elements/LineElement'
+import EmojiVoid from './elements/EmojiVoid'
+import CustomEmojiVoid from './elements/CustomEmojiVoid'
+import UserMentionVoid from './elements/UserMentionVoid'
+import ChannelMentionVoid from './elements/ChannelMentionVoid'
 import FormattedLeaf from './leaves/FormattedLeaf'
 import { decorateMarkdown } from './decorations'
+import type {
+  EmojiElement,
+  CustomEmojiElement,
+  UserMentionElement,
+  ChannelMentionElement,
+} from './types'
 
 interface Props {
   placeholder?: string
@@ -21,10 +31,15 @@ export default function VesperEditable({
   const renderElement = useCallback(
     (props: RenderElementProps) => {
       switch (props.element.type) {
+        case 'emoji':
+          return <EmojiVoid {...props} element={props.element as EmojiElement} />
+        case 'custom-emoji':
+          return <CustomEmojiVoid {...props} element={props.element as CustomEmojiElement} />
+        case 'user-mention':
+          return <UserMentionVoid {...props} element={props.element as UserMentionElement} />
+        case 'channel-mention':
+          return <ChannelMentionVoid {...props} element={props.element as ChannelMentionElement} />
         case 'line':
-          return <LineElement {...props} />
-        // Phase 4: blockquote, code-block, code-block-line
-        // Phase 3: emoji, custom-emoji, user-mention, channel-mention
         default:
           return <LineElement {...props} />
       }

--- a/client/src/renderer/src/components/chat/slate/VesperEditor.tsx
+++ b/client/src/renderer/src/components/chat/slate/VesperEditor.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { Slate, type ReactEditor } from 'slate-react'
+import { Editor, Transforms, Node } from 'slate'
+import { createVesperEditor } from './createVesperEditor'
+import { serializeToMarkdown } from './serialize'
+import { emptyDocument } from './types'
+import VesperEditable from './VesperEditable'
+
+interface Props {
+  onSubmit: (markdown: string) => void
+  onCancel?: () => void
+  onChange?: (markdown: string) => void
+  onTypingStart?: () => void
+  onTypingStop?: () => void
+  placeholder?: string
+  initialValue?: string
+  mode?: 'compose' | 'edit'
+  autoFocus?: boolean
+}
+
+export default function VesperEditor({
+  onSubmit,
+  onCancel,
+  onChange,
+  onTypingStart,
+  onTypingStop,
+  placeholder,
+  initialValue,
+  mode = 'compose',
+  autoFocus = false,
+}: Props): React.JSX.Element {
+  const submitRef = useRef(onSubmit)
+  submitRef.current = onSubmit
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+  const typingStartRef = useRef(onTypingStart)
+  typingStartRef.current = onTypingStart
+  const typingStopRef = useRef(onTypingStop)
+  typingStopRef.current = onTypingStop
+
+  const handleSubmit = useCallback(() => {
+    const ed = editorRef.current
+    if (!ed) return
+    const markdown = serializeToMarkdown(ed.children)
+    if (!markdown.trim()) return
+    submitRef.current(markdown)
+    // Reset editor
+    Transforms.delete(ed, {
+      at: {
+        anchor: Editor.start(ed, []),
+        focus: Editor.end(ed, []),
+      },
+    })
+    Transforms.removeNodes(ed, { at: [0], mode: 'highest' })
+    Transforms.insertNodes(ed, emptyDocument()[0], { at: [0] })
+    // Remove any extra nodes that might have been left
+    while (ed.children.length > 1) {
+      Transforms.removeNodes(ed, { at: [ed.children.length - 1] })
+    }
+    Transforms.select(ed, Editor.start(ed, []))
+  }, [])
+
+  const editor = useMemo(
+    () => createVesperEditor({ onSubmit: handleSubmit }),
+    [handleSubmit]
+  )
+  const editorRef = useRef<typeof editor>(editor)
+  editorRef.current = editor
+
+  const initialSlateValue = useMemo(() => {
+    if (initialValue) {
+      return [{ type: 'line' as const, children: [{ text: initialValue }] }]
+    }
+    return emptyDocument()
+  }, [initialValue])
+
+  const handleChange = useCallback(() => {
+    const ed = editorRef.current
+    if (!ed) return
+    const markdown = serializeToMarkdown(ed.children)
+    onChangeRef.current?.(markdown)
+
+    if (markdown.trim()) {
+      typingStartRef.current?.()
+    } else {
+      typingStopRef.current?.()
+    }
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault()
+        handleSubmit()
+        return
+      }
+
+      if (event.key === 'Escape' && mode === 'edit') {
+        event.preventDefault()
+        onCancel?.()
+        return
+      }
+    },
+    [handleSubmit, mode, onCancel]
+  )
+
+  return (
+    <Slate editor={editor} initialValue={initialSlateValue} onChange={handleChange}>
+      <VesperEditable
+        placeholder={placeholder}
+        onKeyDown={handleKeyDown}
+        autoFocus={autoFocus}
+      />
+    </Slate>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/autocomplete.ts
+++ b/client/src/renderer/src/components/chat/slate/autocomplete.ts
@@ -1,0 +1,105 @@
+import { Editor, Transforms, Range } from 'slate'
+import type { ComposerAutocompleteItem } from '../ComposerAutocomplete'
+
+/**
+ * Insert a void node from autocomplete selection into the Slate editor.
+ * Deletes the trigger text (e.g. "@query") and inserts the appropriate void element.
+ */
+export function insertAutocompleteResult(
+  editor: Editor,
+  item: ComposerAutocompleteItem,
+  triggerStart: number
+): void {
+  const { selection } = editor
+  if (!selection || !Range.isCollapsed(selection)) return
+
+  const focus = selection.focus
+  // Delete from trigger start to current cursor
+  const deleteRange = {
+    anchor: { path: focus.path, offset: triggerStart },
+    focus,
+  }
+  Transforms.delete(editor, { at: deleteRange })
+
+  if (item.type === 'user') {
+    Transforms.insertNodes(editor, {
+      type: 'user-mention',
+      userId: item.id,
+      displayName: item.label,
+      children: [{ text: '' }],
+    })
+  } else if (item.type === 'everyone') {
+    Transforms.insertNodes(editor, {
+      type: 'user-mention',
+      userId: 'everyone',
+      displayName: 'everyone',
+      children: [{ text: '' }],
+    })
+  } else if (item.type === 'channel') {
+    Transforms.insertNodes(editor, {
+      type: 'channel-mention',
+      channelId: item.id,
+      channelName: item.label,
+      children: [{ text: '' }],
+    })
+  } else if (item.type === 'emoji' && item.emojiGlyph) {
+    Transforms.insertNodes(editor, {
+      type: 'emoji',
+      unicode: item.emojiGlyph,
+      children: [{ text: '' }],
+    })
+  }
+
+  // Insert trailing space and move cursor after it
+  Transforms.insertText(editor, ' ')
+}
+
+/**
+ * Detect autocomplete trigger from Slate editor state.
+ * Walks backward from cursor to find @, #, or : trigger characters.
+ */
+export function detectSlateTrigger(
+  editor: Editor
+): { type: 'mention' | 'channel' | 'emoji'; query: string; start: number } | null {
+  const { selection } = editor
+  if (!selection || !Range.isCollapsed(selection)) return null
+
+  const [start] = Range.edges(selection)
+
+  // Get the text node at cursor
+  const [node] = Editor.node(editor, start.path)
+  if (!('text' in node)) return null
+
+  const textBeforeCursor = node.text.slice(0, start.offset)
+
+  // Walk backward to find a trigger character
+  for (let i = textBeforeCursor.length - 1; i >= 0; i--) {
+    const ch = textBeforeCursor[i]
+
+    // Stop at whitespace — no trigger across word boundaries
+    if (/\s/.test(ch)) return null
+
+    if (ch === '@') {
+      return {
+        type: 'mention',
+        query: textBeforeCursor.slice(i + 1),
+        start: i,
+      }
+    }
+    if (ch === '#') {
+      return {
+        type: 'channel',
+        query: textBeforeCursor.slice(i + 1),
+        start: i,
+      }
+    }
+    if (ch === ':' && i < textBeforeCursor.length - 1) {
+      const query = textBeforeCursor.slice(i + 1)
+      if (query.length >= 2) {
+        return { type: 'emoji', query, start: i }
+      }
+    }
+  }
+
+  return null
+}

--- a/client/src/renderer/src/components/chat/slate/autocomplete.ts
+++ b/client/src/renderer/src/components/chat/slate/autocomplete.ts
@@ -1,5 +1,6 @@
-import { Editor, Transforms, Range } from 'slate'
+import { Editor, Transforms, Range, Node, Text } from 'slate'
 import type { ComposerAutocompleteItem } from '../ComposerAutocomplete'
+import type { CustomElement } from './types'
 
 /**
  * Insert a void node from autocomplete selection into the Slate editor.
@@ -21,37 +22,42 @@ export function insertAutocompleteResult(
   }
   Transforms.delete(editor, { at: deleteRange })
 
+  let node: CustomElement | null = null
+
   if (item.type === 'user') {
-    Transforms.insertNodes(editor, {
+    node = {
       type: 'user-mention',
       userId: item.id,
       displayName: item.label,
       children: [{ text: '' }],
-    })
+    }
   } else if (item.type === 'everyone') {
-    Transforms.insertNodes(editor, {
+    node = {
       type: 'user-mention',
       userId: 'everyone',
       displayName: 'everyone',
       children: [{ text: '' }],
-    })
+    }
   } else if (item.type === 'channel') {
-    Transforms.insertNodes(editor, {
+    node = {
       type: 'channel-mention',
       channelId: item.id,
       channelName: item.label,
       children: [{ text: '' }],
-    })
+    }
   } else if (item.type === 'emoji' && item.emojiGlyph) {
-    Transforms.insertNodes(editor, {
+    node = {
       type: 'emoji',
       unicode: item.emojiGlyph,
       children: [{ text: '' }],
-    })
+    }
   }
 
-  // Insert trailing space and move cursor after it
-  Transforms.insertText(editor, ' ')
+  if (node) {
+    Transforms.insertNodes(editor, [node, { text: ' ' }])
+    // Move cursor to after the space
+    Transforms.move(editor, { distance: 1 })
+  }
 }
 
 /**
@@ -67,8 +73,9 @@ export function detectSlateTrigger(
   const [start] = Range.edges(selection)
 
   // Get the text node at cursor
-  const [node] = Editor.node(editor, start.path)
-  if (!('text' in node)) return null
+  const entry = Editor.node(editor, start.path)
+  const node = entry[0]
+  if (!Text.isText(node)) return null
 
   const textBeforeCursor = node.text.slice(0, start.offset)
 
@@ -93,11 +100,9 @@ export function detectSlateTrigger(
         start: i,
       }
     }
-    if (ch === ':' && i < textBeforeCursor.length - 1) {
+    if (ch === ':') {
       const query = textBeforeCursor.slice(i + 1)
-      if (query.length >= 2) {
-        return { type: 'emoji', query, start: i }
-      }
+      return { type: 'emoji', query, start: i }
     }
   }
 

--- a/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
+++ b/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
@@ -5,6 +5,7 @@ import { withInlineVoids } from './plugins/withInlineVoids'
 import { withSoftBreak } from './plugins/withSoftBreak'
 import { withBlockQuotes } from './plugins/withBlockQuotes'
 import { withCodeBlocks } from './plugins/withCodeBlocks'
+import { withMaxLength } from './plugins/withMaxLength'
 
 export interface VesperEditorOptions {
   onSubmit: () => void
@@ -12,15 +13,17 @@ export interface VesperEditorOptions {
 
 export function createVesperEditor(options: VesperEditorOptions) {
   const base = createEditor()
-  const editor = withCodeBlocks(
-    withBlockQuotes(
-      withSoftBreak(
-        withInlineVoids(
-          withReact(
-            withHistory(base)
-          )
-        ),
-        options.onSubmit
+  const editor = withMaxLength(
+    withCodeBlocks(
+      withBlockQuotes(
+        withSoftBreak(
+          withInlineVoids(
+            withReact(
+              withHistory(base)
+            )
+          ),
+          options.onSubmit
+        )
       )
     )
   )

--- a/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
+++ b/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
@@ -3,7 +3,8 @@ import { withReact } from 'slate-react'
 import { withHistory } from 'slate-history'
 import { withInlineVoids } from './plugins/withInlineVoids'
 import { withSoftBreak } from './plugins/withSoftBreak'
-import type { emptyDocument } from './types'
+import { withBlockQuotes } from './plugins/withBlockQuotes'
+import { withCodeBlocks } from './plugins/withCodeBlocks'
 
 export interface VesperEditorOptions {
   onSubmit: () => void
@@ -11,13 +12,17 @@ export interface VesperEditorOptions {
 
 export function createVesperEditor(options: VesperEditorOptions) {
   const base = createEditor()
-  const withPlugins = withSoftBreak(
-    withInlineVoids(
-      withReact(
-        withHistory(base)
+  const editor = withCodeBlocks(
+    withBlockQuotes(
+      withSoftBreak(
+        withInlineVoids(
+          withReact(
+            withHistory(base)
+          )
+        ),
+        options.onSubmit
       )
-    ),
-    options.onSubmit
+    )
   )
-  return withPlugins
+  return editor
 }

--- a/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
+++ b/client/src/renderer/src/components/chat/slate/createVesperEditor.ts
@@ -1,0 +1,23 @@
+import { createEditor } from 'slate'
+import { withReact } from 'slate-react'
+import { withHistory } from 'slate-history'
+import { withInlineVoids } from './plugins/withInlineVoids'
+import { withSoftBreak } from './plugins/withSoftBreak'
+import type { emptyDocument } from './types'
+
+export interface VesperEditorOptions {
+  onSubmit: () => void
+}
+
+export function createVesperEditor(options: VesperEditorOptions) {
+  const base = createEditor()
+  const withPlugins = withSoftBreak(
+    withInlineVoids(
+      withReact(
+        withHistory(base)
+      )
+    ),
+    options.onSubmit
+  )
+  return withPlugins
+}

--- a/client/src/renderer/src/components/chat/slate/decorations.ts
+++ b/client/src/renderer/src/components/chat/slate/decorations.ts
@@ -1,0 +1,149 @@
+import { Text, type NodeEntry, type Range, Element } from 'slate'
+
+/**
+ * Decorate function for the Slate editor. Applies visual-only formatting
+ * to text leaves based on inline markdown patterns. The document text
+ * retains the raw markdown syntax — decorations just control how it renders.
+ */
+export function decorateMarkdown([node, path]: NodeEntry): Range[] {
+  if (!Text.isText(node)) return []
+  const { text } = node
+  if (!text) return []
+
+  const ranges: Range[] = []
+
+  // Bold: **text** or __text__
+  for (const match of text.matchAll(/(\*\*|__)(.+?)\1/g)) {
+    const start = match.index!
+    const delim = match[1].length
+    const contentStart = start + delim
+    const contentEnd = contentStart + match[2].length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: start + delim },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: contentStart },
+      focus: { path, offset: contentEnd },
+      bold: true,
+    } as Range & { bold: true })
+    ranges.push({
+      anchor: { path, offset: contentEnd },
+      focus: { path, offset: contentEnd + delim },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+  }
+
+  // Italic: *text* or _text_ (but not ** or __)
+  for (const match of text.matchAll(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)|(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g)) {
+    const start = match.index!
+    const content = match[1] ?? match[2]
+    const contentStart = start + 1
+    const contentEnd = contentStart + content.length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: start + 1 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: contentStart },
+      focus: { path, offset: contentEnd },
+      italic: true,
+    } as Range & { italic: true })
+    ranges.push({
+      anchor: { path, offset: contentEnd },
+      focus: { path, offset: contentEnd + 1 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+  }
+
+  // Strikethrough: ~~text~~
+  for (const match of text.matchAll(/~~(.+?)~~/g)) {
+    const start = match.index!
+    const contentStart = start + 2
+    const contentEnd = contentStart + match[1].length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: start + 2 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: contentStart },
+      focus: { path, offset: contentEnd },
+      strikethrough: true,
+    } as Range & { strikethrough: true })
+    ranges.push({
+      anchor: { path, offset: contentEnd },
+      focus: { path, offset: contentEnd + 2 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+  }
+
+  // Inline code: `text`
+  for (const match of text.matchAll(/(?<!`)`(?!`)([^`]+?)(?<!`)`(?!`)/g)) {
+    const start = match.index!
+    const contentStart = start + 1
+    const contentEnd = contentStart + match[1].length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: start + 1 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: contentStart },
+      focus: { path, offset: contentEnd },
+      inlineCode: true,
+    } as Range & { inlineCode: true })
+    ranges.push({
+      anchor: { path, offset: contentEnd },
+      focus: { path, offset: contentEnd + 1 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+  }
+
+  // Spoiler: ||text||
+  for (const match of text.matchAll(/\|\|(.+?)\|\|/g)) {
+    const start = match.index!
+    const contentStart = start + 2
+    const contentEnd = contentStart + match[1].length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: start + 2 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: contentStart },
+      focus: { path, offset: contentEnd },
+      spoiler: true,
+    } as Range & { spoiler: true })
+    ranges.push({
+      anchor: { path, offset: contentEnd },
+      focus: { path, offset: contentEnd + 2 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+  }
+
+  // Underline: __text__ (distinct from bold — Discord uses __ for underline)
+  // Note: this overlaps with bold __. For simplicity, __text__ renders as bold
+  // (matching the more common convention). True underline would need a separate syntax.
+
+  // Links: https://... or http://...
+  for (const match of text.matchAll(/https?:\/\/[^\s<>"]+/g)) {
+    const start = match.index!
+    const end = start + match[0].length
+
+    ranges.push({
+      anchor: { path, offset: start },
+      focus: { path, offset: end },
+      link: match[0],
+    } as Range & { link: string })
+  }
+
+  return ranges
+}

--- a/client/src/renderer/src/components/chat/slate/decorations.ts
+++ b/client/src/renderer/src/components/chat/slate/decorations.ts
@@ -145,5 +145,19 @@ export function decorateMarkdown([node, path]: NodeEntry): Range[] {
     } as Range & { link: string })
   }
 
+  // Blockquote: line starting with "> "
+  if (text.startsWith('> ')) {
+    ranges.push({
+      anchor: { path, offset: 0 },
+      focus: { path, offset: 2 },
+      syntaxMark: true,
+    } as Range & { syntaxMark: true })
+    ranges.push({
+      anchor: { path, offset: 2 },
+      focus: { path, offset: text.length },
+      blockquote: true,
+    } as Range & { blockquote: true })
+  }
+
   return ranges
 }

--- a/client/src/renderer/src/components/chat/slate/deserialize.ts
+++ b/client/src/renderer/src/components/chat/slate/deserialize.ts
@@ -1,0 +1,114 @@
+import type { Descendant } from 'slate'
+
+const MENTION_REGEX = /<@([0-9a-f-]{36}|everyone)>/g
+const CHANNEL_REGEX = /<#([0-9a-f-]{36})>/g
+const CUSTOM_EMOJI_REGEX = /<(a?):([a-zA-Z0-9_~-]{2,32}):([a-zA-Z0-9_-]+)>/g
+
+interface MemberLookup {
+  get(userId: string): { displayName: string } | undefined
+}
+
+interface ChannelLookup {
+  get(channelId: string): { name: string } | undefined
+}
+
+/**
+ * Deserialize a markdown string (with wire tokens) into a Slate document.
+ * Used for editing existing messages.
+ *
+ * For now, handles line splitting and basic token replacement.
+ * Void nodes (mentions, emoji) are inserted as inline elements.
+ */
+export function deserializeMarkdown(
+  markdown: string,
+  members?: MemberLookup,
+  channels?: ChannelLookup
+): Descendant[] {
+  const lines = markdown.split('\n')
+  const result: Descendant[] = []
+
+  for (const line of lines) {
+    const children: Descendant[] = []
+    let remaining = line
+    let lastIndex = 0
+
+    // Combine all token patterns and process in order
+    const tokens: Array<{
+      index: number
+      length: number
+      node: Descendant
+    }> = []
+
+    // Find mentions
+    for (const match of line.matchAll(MENTION_REGEX)) {
+      const userId = match[1]
+      if (userId === 'everyone') {
+        tokens.push({
+          index: match.index!,
+          length: match[0].length,
+          node: {
+            type: 'user-mention',
+            userId: 'everyone',
+            displayName: 'everyone',
+            children: [{ text: '' }],
+          },
+        })
+      } else {
+        const member = members?.get(userId)
+        tokens.push({
+          index: match.index!,
+          length: match[0].length,
+          node: {
+            type: 'user-mention',
+            userId,
+            displayName: member?.displayName ?? userId.slice(0, 8),
+            children: [{ text: '' }],
+          },
+        })
+      }
+    }
+
+    // Find channels
+    for (const match of line.matchAll(CHANNEL_REGEX)) {
+      const channelId = match[1]
+      const channel = channels?.get(channelId)
+      tokens.push({
+        index: match.index!,
+        length: match[0].length,
+        node: {
+          type: 'channel-mention',
+          channelId,
+          channelName: channel?.name ?? channelId.slice(0, 8),
+          children: [{ text: '' }],
+        },
+      })
+    }
+
+    // Sort tokens by position
+    tokens.sort((a, b) => a.index - b.index)
+
+    // Build children array with text between tokens
+    let cursor = 0
+    for (const token of tokens) {
+      if (token.index > cursor) {
+        children.push({ text: line.slice(cursor, token.index) })
+      }
+      children.push(token.node)
+      cursor = token.index + token.length
+    }
+
+    // Add remaining text
+    if (cursor < line.length) {
+      children.push({ text: line.slice(cursor) })
+    }
+
+    // Ensure at least one child
+    if (children.length === 0) {
+      children.push({ text: '' })
+    }
+
+    result.push({ type: 'line', children })
+  }
+
+  return result.length > 0 ? result : [{ type: 'line', children: [{ text: '' }] }]
+}

--- a/client/src/renderer/src/components/chat/slate/elements/BlockQuoteElement.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/BlockQuoteElement.tsx
@@ -1,0 +1,12 @@
+import type { RenderElementProps } from 'slate-react'
+
+export default function BlockQuoteElement({
+  attributes,
+  children,
+}: RenderElementProps): React.JSX.Element {
+  return (
+    <div {...attributes} className="vesper-slate-blockquote">
+      {children}
+    </div>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/elements/ChannelMentionVoid.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/ChannelMentionVoid.tsx
@@ -1,0 +1,15 @@
+import type { RenderElementProps } from 'slate-react'
+import type { ChannelMentionElement } from '../types'
+
+export default function ChannelMentionVoid({
+  attributes,
+  children,
+  element,
+}: RenderElementProps & { element: ChannelMentionElement }): React.JSX.Element {
+  return (
+    <span {...attributes} contentEditable={false} className="vesper-slate-inline-void vesper-slate-channel-mention">
+      #{element.channelName}
+      {children}
+    </span>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/elements/CodeBlockElement.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/CodeBlockElement.tsx
@@ -1,0 +1,21 @@
+import type { RenderElementProps } from 'slate-react'
+import type { CodeBlockElement as CodeBlockElementType } from '../types'
+
+export default function CodeBlockElement({
+  attributes,
+  children,
+  element,
+}: RenderElementProps & { element: CodeBlockElementType }): React.JSX.Element {
+  return (
+    <div {...attributes} className="vesper-slate-code-block">
+      {element.language && (
+        <div className="vesper-slate-code-lang" contentEditable={false}>
+          {element.language}
+        </div>
+      )}
+      <pre>
+        <code>{children}</code>
+      </pre>
+    </div>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/elements/CustomEmojiVoid.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/CustomEmojiVoid.tsx
@@ -1,0 +1,21 @@
+import type { RenderElementProps } from 'slate-react'
+import type { CustomEmojiElement } from '../types'
+
+export default function CustomEmojiVoid({
+  attributes,
+  children,
+  element,
+}: RenderElementProps & { element: CustomEmojiElement }): React.JSX.Element {
+  return (
+    <span {...attributes} contentEditable={false} className="vesper-slate-inline-void vesper-slate-emoji">
+      <img
+        src={element.url}
+        alt={`:${element.name}:`}
+        draggable={false}
+        className="vesper-emoji-image"
+        data-emoji-name={element.name}
+      />
+      {children}
+    </span>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/elements/EmojiVoid.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/EmojiVoid.tsx
@@ -1,0 +1,28 @@
+import type { RenderElementProps } from 'slate-react'
+import type { EmojiElement } from '../types'
+import { emojiToTwemojiUrl, twemojiFallback } from '../../../../utils/twemoji'
+
+export default function EmojiVoid({
+  attributes,
+  children,
+  element,
+}: RenderElementProps & { element: EmojiElement }): React.JSX.Element {
+  const url = emojiToTwemojiUrl(element.unicode)
+
+  return (
+    <span {...attributes} contentEditable={false} className="vesper-slate-inline-void vesper-slate-emoji">
+      {url ? (
+        <img
+          src={url}
+          alt={element.unicode}
+          draggable={false}
+          className="vesper-emoji-image"
+          onError={twemojiFallback}
+        />
+      ) : (
+        <span className="vesper-emoji-text" aria-hidden="true">{element.unicode}</span>
+      )}
+      {children}
+    </span>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/elements/LineElement.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/LineElement.tsx
@@ -1,0 +1,8 @@
+import type { RenderElementProps } from 'slate-react'
+
+export default function LineElement({
+  attributes,
+  children,
+}: RenderElementProps): React.JSX.Element {
+  return <div {...attributes}>{children}</div>
+}

--- a/client/src/renderer/src/components/chat/slate/elements/UserMentionVoid.tsx
+++ b/client/src/renderer/src/components/chat/slate/elements/UserMentionVoid.tsx
@@ -1,0 +1,15 @@
+import type { RenderElementProps } from 'slate-react'
+import type { UserMentionElement } from '../types'
+
+export default function UserMentionVoid({
+  attributes,
+  children,
+  element,
+}: RenderElementProps & { element: UserMentionElement }): React.JSX.Element {
+  return (
+    <span {...attributes} contentEditable={false} className="vesper-slate-inline-void vesper-slate-mention">
+      @{element.displayName}
+      {children}
+    </span>
+  )
+}

--- a/client/src/renderer/src/components/chat/slate/leaves/FormattedLeaf.tsx
+++ b/client/src/renderer/src/components/chat/slate/leaves/FormattedLeaf.tsx
@@ -25,6 +25,9 @@ export default function FormattedLeaf({
   if (leaf.spoiler) {
     content = <span className="vesper-slate-spoiler-composer">{content}</span>
   }
+  if (leaf.blockquote) {
+    content = <span className="vesper-slate-blockquote-text">{content}</span>
+  }
   if (leaf.link) {
     content = <span className="vesper-slate-link">{content}</span>
   }

--- a/client/src/renderer/src/components/chat/slate/leaves/FormattedLeaf.tsx
+++ b/client/src/renderer/src/components/chat/slate/leaves/FormattedLeaf.tsx
@@ -1,0 +1,36 @@
+import type { RenderLeafProps } from 'slate-react'
+
+export default function FormattedLeaf({
+  attributes,
+  children,
+  leaf,
+}: RenderLeafProps): React.JSX.Element {
+  let content = children
+
+  if (leaf.bold) {
+    content = <strong className="vesper-slate-bold">{content}</strong>
+  }
+  if (leaf.italic) {
+    content = <em className="vesper-slate-italic">{content}</em>
+  }
+  if (leaf.underline) {
+    content = <u className="vesper-slate-underline">{content}</u>
+  }
+  if (leaf.strikethrough) {
+    content = <s className="vesper-slate-strikethrough">{content}</s>
+  }
+  if (leaf.inlineCode) {
+    content = <code className="vesper-slate-inline-code">{content}</code>
+  }
+  if (leaf.spoiler) {
+    content = <span className="vesper-slate-spoiler-composer">{content}</span>
+  }
+  if (leaf.link) {
+    content = <span className="vesper-slate-link">{content}</span>
+  }
+  if (leaf.syntaxMark) {
+    content = <span className="vesper-slate-syntax-mark">{content}</span>
+  }
+
+  return <span {...attributes}>{content}</span>
+}

--- a/client/src/renderer/src/components/chat/slate/plugins/withBlockQuotes.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withBlockQuotes.ts
@@ -1,0 +1,82 @@
+import { Editor, Transforms, Element, Node, Range, Point } from 'slate'
+
+/**
+ * Handles `> ` at the start of a line to create a blockquote element.
+ * Enter inside a blockquote continues it. Enter on empty blockquote line exits.
+ */
+export function withBlockQuotes(editor: Editor): Editor {
+  const { insertText, insertBreak, deleteBackward } = editor
+
+  editor.insertText = (text) => {
+    const { selection } = editor
+    if (text === ' ' && selection && Range.isCollapsed(selection)) {
+      const [node, path] = Editor.node(editor, selection.focus.path)
+      if ('text' in node && node.text === '>' && selection.focus.offset === 1) {
+        // User typed "> " — convert line to blockquote
+        const linePath = path.slice(0, -1)
+        const [lineNode] = Editor.node(editor, linePath)
+        if (Element.isElement(lineNode) && lineNode.type === 'line') {
+          // Delete the ">" text
+          Transforms.delete(editor, {
+            at: { anchor: { path, offset: 0 }, focus: { path, offset: 1 } }
+          })
+          // Wrap in blockquote
+          Transforms.wrapNodes(
+            editor,
+            { type: 'blockquote', children: [] },
+            { at: linePath }
+          )
+          return
+        }
+      }
+    }
+    insertText(text)
+  }
+
+  editor.insertBreak = () => {
+    const { selection } = editor
+    if (selection && Range.isCollapsed(selection)) {
+      const [match] = Editor.nodes(editor, {
+        match: (n) => Element.isElement(n) && n.type === 'blockquote',
+      })
+      if (match) {
+        const [, blockquotePath] = match
+        // If current line is empty inside blockquote, exit the blockquote
+        const [lineNode] = Editor.node(editor, selection.focus.path.slice(0, -1))
+        if (Element.isElement(lineNode) && Node.string(lineNode) === '') {
+          // Unwrap from blockquote and insert a new line after
+          Transforms.unwrapNodes(editor, {
+            match: (n) => Element.isElement(n) && n.type === 'blockquote',
+            split: true,
+          })
+          return
+        }
+      }
+    }
+    insertBreak()
+  }
+
+  editor.deleteBackward = (unit) => {
+    const { selection } = editor
+    if (selection && Range.isCollapsed(selection)) {
+      const [match] = Editor.nodes(editor, {
+        match: (n) => Element.isElement(n) && n.type === 'blockquote',
+      })
+      if (match) {
+        const [, blockquotePath] = match
+        // If at start of blockquote content, unwrap
+        const start = Editor.start(editor, blockquotePath)
+        if (Point.equals(selection.focus, start)) {
+          Transforms.unwrapNodes(editor, {
+            match: (n) => Element.isElement(n) && n.type === 'blockquote',
+            split: true,
+          })
+          return
+        }
+      }
+    }
+    deleteBackward(unit)
+  }
+
+  return editor
+}

--- a/client/src/renderer/src/components/chat/slate/plugins/withBlockQuotes.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withBlockQuotes.ts
@@ -1,82 +1,12 @@
 import { Editor, Transforms, Element, Node, Range, Point } from 'slate'
 
 /**
- * Handles `> ` at the start of a line to create a blockquote element.
- * Enter inside a blockquote continues it. Enter on empty blockquote line exits.
+ * Minimal blockquote support — just handles backspace at the start of a
+ * line beginning with "> " to remove the prefix. Everything else is
+ * handled by the decoration system (visual styling of > lines).
  */
 export function withBlockQuotes(editor: Editor): Editor {
-  const { insertText, insertBreak, deleteBackward } = editor
-
-  editor.insertText = (text) => {
-    const { selection } = editor
-    if (text === ' ' && selection && Range.isCollapsed(selection)) {
-      const [node, path] = Editor.node(editor, selection.focus.path)
-      if ('text' in node && node.text === '>' && selection.focus.offset === 1) {
-        // User typed "> " — convert line to blockquote
-        const linePath = path.slice(0, -1)
-        const [lineNode] = Editor.node(editor, linePath)
-        if (Element.isElement(lineNode) && lineNode.type === 'line') {
-          // Delete the ">" text
-          Transforms.delete(editor, {
-            at: { anchor: { path, offset: 0 }, focus: { path, offset: 1 } }
-          })
-          // Wrap in blockquote
-          Transforms.wrapNodes(
-            editor,
-            { type: 'blockquote', children: [] },
-            { at: linePath }
-          )
-          return
-        }
-      }
-    }
-    insertText(text)
-  }
-
-  editor.insertBreak = () => {
-    const { selection } = editor
-    if (selection && Range.isCollapsed(selection)) {
-      const [match] = Editor.nodes(editor, {
-        match: (n) => Element.isElement(n) && n.type === 'blockquote',
-      })
-      if (match) {
-        const [, blockquotePath] = match
-        // If current line is empty inside blockquote, exit the blockquote
-        const [lineNode] = Editor.node(editor, selection.focus.path.slice(0, -1))
-        if (Element.isElement(lineNode) && Node.string(lineNode) === '') {
-          // Unwrap from blockquote and insert a new line after
-          Transforms.unwrapNodes(editor, {
-            match: (n) => Element.isElement(n) && n.type === 'blockquote',
-            split: true,
-          })
-          return
-        }
-      }
-    }
-    insertBreak()
-  }
-
-  editor.deleteBackward = (unit) => {
-    const { selection } = editor
-    if (selection && Range.isCollapsed(selection)) {
-      const [match] = Editor.nodes(editor, {
-        match: (n) => Element.isElement(n) && n.type === 'blockquote',
-      })
-      if (match) {
-        const [, blockquotePath] = match
-        // If at start of blockquote content, unwrap
-        const start = Editor.start(editor, blockquotePath)
-        if (Point.equals(selection.focus, start)) {
-          Transforms.unwrapNodes(editor, {
-            match: (n) => Element.isElement(n) && n.type === 'blockquote',
-            split: true,
-          })
-          return
-        }
-      }
-    }
-    deleteBackward(unit)
-  }
-
+  // No-op — blockquotes are now purely decorative (handled by decorations.ts).
+  // The > prefix stays as plain text in the document.
   return editor
 }

--- a/client/src/renderer/src/components/chat/slate/plugins/withCodeBlocks.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withCodeBlocks.ts
@@ -1,0 +1,65 @@
+import { Editor, Transforms, Element, Node, Range, Point } from 'slate'
+
+/**
+ * Handles ``` fence lines to enter/exit code blocks.
+ * When user types ``` on its own line, creates a code-block element.
+ * When user types ``` again on its own line inside code block, exits it.
+ */
+export function withCodeBlocks(editor: Editor): Editor {
+  const { insertText } = editor
+
+  editor.insertText = (text) => {
+    const { selection } = editor
+    if (text === '`' && selection && Range.isCollapsed(selection)) {
+      const [node, path] = Editor.node(editor, selection.focus.path)
+      if ('text' in node) {
+        const textBefore = node.text.slice(0, selection.focus.offset)
+        const linePath = path.slice(0, -1)
+        const [lineNode] = Editor.node(editor, linePath)
+
+        // Check if we're inside a code block and typing the closing fence
+        const [codeBlockMatch] = Editor.nodes(editor, {
+          match: (n) => Element.isElement(n) && n.type === 'code-block',
+        })
+
+        if (codeBlockMatch) {
+          // Inside code block — check for closing ```
+          if (textBefore === '``') {
+            // Delete the `` and unwrap the code block
+            Transforms.delete(editor, {
+              at: { anchor: { path, offset: 0 }, focus: { path, offset: 2 } }
+            })
+            Transforms.unwrapNodes(editor, {
+              match: (n) => Element.isElement(n) && n.type === 'code-block',
+              split: true,
+            })
+            // Convert code-block-line back to regular line
+            Transforms.setNodes(editor, { type: 'line' } as Partial<Element>, {
+              match: (n) => Element.isElement(n) && n.type === 'code-block-line',
+            })
+            return
+          }
+        } else if (textBefore === '``' && Element.isElement(lineNode) && lineNode.type === 'line') {
+          // Not in code block, typed ``` — detect language and create code block
+          // Delete the `` prefix
+          Transforms.delete(editor, {
+            at: { anchor: { path, offset: 0 }, focus: { path, offset: 2 } }
+          })
+          // Convert line to code-block-line and wrap in code-block
+          Transforms.setNodes(editor, { type: 'code-block-line' } as Partial<Element>, {
+            at: linePath,
+          })
+          Transforms.wrapNodes(
+            editor,
+            { type: 'code-block', language: '', children: [] },
+            { at: linePath }
+          )
+          return
+        }
+      }
+    }
+    insertText(text)
+  }
+
+  return editor
+}

--- a/client/src/renderer/src/components/chat/slate/plugins/withInlineVoids.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withInlineVoids.ts
@@ -1,0 +1,14 @@
+import type { Editor } from 'slate'
+import { VOID_TYPES, INLINE_TYPES } from '../types'
+
+export function withInlineVoids(editor: Editor): Editor {
+  const { isInline, isVoid } = editor
+
+  editor.isInline = (element) =>
+    INLINE_TYPES.has(element.type) || isInline(element)
+
+  editor.isVoid = (element) =>
+    VOID_TYPES.has(element.type) || isVoid(element)
+
+  return editor
+}

--- a/client/src/renderer/src/components/chat/slate/plugins/withInlineVoids.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withInlineVoids.ts
@@ -1,14 +1,37 @@
-import type { Editor } from 'slate'
+import { type Editor, Element, Transforms } from 'slate'
 import { VOID_TYPES, INLINE_TYPES } from '../types'
 
 export function withInlineVoids(editor: Editor): Editor {
-  const { isInline, isVoid } = editor
+  const { isInline, isVoid, normalizeNode } = editor
 
-  editor.isInline = (element) =>
-    INLINE_TYPES.has(element.type) || isInline(element)
+  editor.isInline = (element) => {
+    if (INLINE_TYPES.has(element.type)) return true
+    return isInline(element)
+  }
 
-  editor.isVoid = (element) =>
-    VOID_TYPES.has(element.type) || isVoid(element)
+  editor.isVoid = (element) => {
+    if (VOID_TYPES.has(element.type)) return true
+    return isVoid(element)
+  }
+
+  // Safety net: if an inline void somehow ends up as a direct child
+  // of the editor (top-level), wrap it in a line element.
+  editor.normalizeNode = (entry) => {
+    const [node, path] = entry
+    if (
+      path.length === 1 &&
+      Element.isElement(node) &&
+      INLINE_TYPES.has(node.type)
+    ) {
+      Transforms.wrapNodes(
+        editor,
+        { type: 'line', children: [] },
+        { at: path }
+      )
+      return
+    }
+    normalizeNode(entry)
+  }
 
   return editor
 }

--- a/client/src/renderer/src/components/chat/slate/plugins/withMaxLength.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withMaxLength.ts
@@ -1,0 +1,24 @@
+import { Editor, Node } from 'slate'
+
+const MAX_MESSAGE_LENGTH = 4000
+
+/**
+ * Prevents inserting text that would exceed the message length limit.
+ */
+export function withMaxLength(editor: Editor): Editor {
+  const { insertText, insertFragment } = editor
+
+  editor.insertText = (text) => {
+    const currentLength = Editor.string(editor, []).length
+    if (currentLength + text.length > MAX_MESSAGE_LENGTH) {
+      const remaining = MAX_MESSAGE_LENGTH - currentLength
+      if (remaining > 0) {
+        insertText(text.slice(0, remaining))
+      }
+      return
+    }
+    insertText(text)
+  }
+
+  return editor
+}

--- a/client/src/renderer/src/components/chat/slate/plugins/withSoftBreak.ts
+++ b/client/src/renderer/src/components/chat/slate/plugins/withSoftBreak.ts
@@ -1,0 +1,34 @@
+import { Editor, Transforms, Range, Element, Node } from 'slate'
+
+/**
+ * Enter submits the message (calls onSubmit callback).
+ * Shift+Enter inserts a new line element.
+ */
+export function withSoftBreak(
+  editor: Editor,
+  onSubmit: () => void
+): Editor {
+  const { insertBreak } = editor
+
+  editor.insertBreak = () => {
+    // Shift+Enter is handled by the keydown handler in VesperEditable
+    // which calls editor.insertBreak() directly. This default path is
+    // for the normal Enter case, which Slate calls via insertBreak.
+    // We override to insert a new line element instead of splitting.
+    const { selection } = editor
+    if (!selection) return
+
+    // Delete any selected content first
+    if (!Range.isCollapsed(selection)) {
+      Transforms.delete(editor)
+    }
+
+    // Insert a new line element
+    Transforms.insertNodes(editor, {
+      type: 'line',
+      children: [{ text: '' }],
+    })
+  }
+
+  return editor
+}

--- a/client/src/renderer/src/components/chat/slate/serialize.ts
+++ b/client/src/renderer/src/components/chat/slate/serialize.ts
@@ -1,0 +1,52 @@
+import { Node, type Descendant } from 'slate'
+
+/**
+ * Serialize a Slate document to a markdown string.
+ * Because we use the decorations-only approach, text nodes contain raw
+ * markdown syntax. We just need to concatenate text and convert void
+ * nodes to their wire tokens.
+ */
+export function serializeToMarkdown(nodes: Descendant[]): string {
+  return nodes.map(serializeNode).join('\n')
+}
+
+function serializeNode(node: Descendant): string {
+  if ('text' in node) {
+    return node.text
+  }
+
+  switch (node.type) {
+    case 'emoji':
+      return node.unicode
+
+    case 'custom-emoji':
+      return node.token
+
+    case 'user-mention':
+      return `<@${node.userId}>`
+
+    case 'channel-mention':
+      return `<#${node.channelId}>`
+
+    case 'blockquote':
+      return node.children
+        .map((child) => `> ${serializeNode(child)}`)
+        .join('\n')
+
+    case 'code-block':
+      return (
+        '```' +
+        node.language +
+        '\n' +
+        node.children.map(serializeNode).join('\n') +
+        '\n```'
+      )
+
+    case 'code-block-line':
+    case 'line':
+      return node.children.map(serializeNode).join('')
+
+    default:
+      return Node.string(node)
+  }
+}

--- a/client/src/renderer/src/components/chat/slate/types.ts
+++ b/client/src/renderer/src/components/chat/slate/types.ts
@@ -79,6 +79,7 @@ export type CustomText = {
   strikethrough?: true
   inlineCode?: true
   spoiler?: true
+  blockquote?: true
   link?: string
   syntaxMark?: true
   codeBlockText?: true

--- a/client/src/renderer/src/components/chat/slate/types.ts
+++ b/client/src/renderer/src/components/chat/slate/types.ts
@@ -1,0 +1,115 @@
+import type { BaseEditor, Descendant } from 'slate'
+import type { ReactEditor } from 'slate-react'
+import type { HistoryEditor } from 'slate-history'
+
+// --- Block elements ---
+
+export type LineElement = {
+  type: 'line'
+  children: Descendant[]
+}
+
+export type BlockQuoteElement = {
+  type: 'blockquote'
+  children: Descendant[]
+}
+
+export type CodeBlockElement = {
+  type: 'code-block'
+  language: string
+  children: CodeBlockLineElement[]
+}
+
+export type CodeBlockLineElement = {
+  type: 'code-block-line'
+  children: CustomText[]
+}
+
+// --- Inline void elements ---
+
+export type EmojiElement = {
+  type: 'emoji'
+  unicode: string
+  children: [EmptyText]
+}
+
+export type CustomEmojiElement = {
+  type: 'custom-emoji'
+  token: string
+  name: string
+  url: string
+  animated: boolean
+  children: [EmptyText]
+}
+
+export type UserMentionElement = {
+  type: 'user-mention'
+  userId: string
+  displayName: string
+  children: [EmptyText]
+}
+
+export type ChannelMentionElement = {
+  type: 'channel-mention'
+  channelId: string
+  channelName: string
+  children: [EmptyText]
+}
+
+// --- Union types ---
+
+export type CustomElement =
+  | LineElement
+  | BlockQuoteElement
+  | CodeBlockElement
+  | CodeBlockLineElement
+  | EmojiElement
+  | CustomEmojiElement
+  | UserMentionElement
+  | ChannelMentionElement
+
+export type EmptyText = { text: '' }
+
+export type CustomText = {
+  text: string
+  // Leaf decorations (applied by decorate, not stored)
+  bold?: true
+  italic?: true
+  underline?: true
+  strikethrough?: true
+  inlineCode?: true
+  spoiler?: true
+  link?: string
+  syntaxMark?: true
+  codeBlockText?: true
+}
+
+// --- Slate module augmentation ---
+
+declare module 'slate' {
+  interface CustomTypes {
+    Editor: BaseEditor & ReactEditor & HistoryEditor
+    Element: CustomElement
+    Text: CustomText
+  }
+}
+
+// --- Helpers ---
+
+export const VOID_TYPES = new Set([
+  'emoji',
+  'custom-emoji',
+  'user-mention',
+  'channel-mention',
+])
+
+export const INLINE_TYPES = new Set([
+  'emoji',
+  'custom-emoji',
+  'user-mention',
+  'channel-mention',
+])
+
+export function emptyDocument(): Descendant[] {
+  return [{ type: 'line', children: [{ text: '' }] }]
+}

--- a/client/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/client/src/renderer/src/components/settings/SettingsModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { Bell, Globe, Laptop2, Mic, Moon, Palette, Pencil, Shield, Sun, UserRound, Volume2 } from 'lucide-react'
+import { Bell, Globe, Laptop2, Lock, Mic, Moon, Palette, Pencil, Shield, Sun, UserRound, Volume2 } from 'lucide-react'
 import { getLocalDeviceIdentity } from '@vesper/sdk/auth'
 import { usePresenceStore } from '../../stores/presenceStore'
 import { useUIStore } from '../../stores/uiStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useVoiceStore } from '../../stores/voiceStore'
 import { useAuthStore } from '../../stores/authStore'
@@ -13,7 +14,7 @@ import SettingsShell, { type SettingsSectionGroup } from './SettingsShell'
 import { getStoredValue, setStoredValue, getStoredJson, setStoredJson } from '../../utils/localStorage'
 import { type ThemeOption, applyTheme, watchSystemTheme } from '../../utils/theme'
 
-type UserSettingsSection = 'profile' | 'appearance' | 'notifications' | 'voice' | 'advanced'
+type UserSettingsSection = 'profile' | 'appearance' | 'notifications' | 'voice' | 'privacy' | 'advanced'
 
 interface AudioDevice {
   deviceId: string
@@ -171,6 +172,10 @@ export default function SettingsModal(): React.JSX.Element {
   const revokeDevice = useAuthStore((s) => s.revokeDevice)
   const myStatus = usePresenceStore((s) => s.myStatus)
   const localDevice = getLocalDeviceIdentity()
+  const anonFilenames = useSettingsStore((s) => s.anonFilenames)
+  const setAnonFilenames = useSettingsStore((s) => s.setAnonFilenames)
+  const stripExif = useSettingsStore((s) => s.stripExif)
+  const setStripExif = useSettingsStore((s) => s.setStripExif)
 
   const avatarInputRef = useRef<HTMLInputElement>(null)
   const bannerInputRef = useRef<HTMLInputElement>(null)
@@ -215,6 +220,7 @@ export default function SettingsModal(): React.JSX.Element {
         { id: 'appearance', label: 'Appearance', icon: Palette },
         { id: 'notifications', label: 'Notifications', icon: Bell },
         { id: 'voice', label: 'Voice & Video', icon: Volume2 },
+        { id: 'privacy', label: 'Privacy', icon: Lock },
         { id: 'advanced', label: 'Advanced', icon: Shield }
       ]
     }
@@ -735,6 +741,56 @@ export default function SettingsModal(): React.JSX.Element {
             >
               {testingSpeaker ? 'Testing...' : 'Play Test Tone'}
             </button>
+          </div>
+        </>
+      )}
+
+      {activeSection === 'privacy' && (
+        <>
+          <div className="vesper-settings-page-header">
+            <div>
+              <h1 className="vesper-settings-page-title">Privacy</h1>
+            </div>
+          </div>
+
+          <div className="vesper-settings-section-heading">File Uploads</div>
+
+          <div className="vesper-settings-stack">
+            <div className="vesper-settings-row">
+              <div>
+                <div className="vesper-settings-row-title">Anonymous Filenames</div>
+                <div className="vesper-settings-row-copy">
+                  Replace original filenames with random characters when uploading. Prevents leaking file naming patterns or personal info in filenames.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAnonFilenames(!anonFilenames)}
+                className={anonFilenames ? 'vesper-settings-toggle vesper-settings-toggle-on' : 'vesper-settings-toggle'}
+                aria-pressed={anonFilenames}
+                aria-label="Anonymous Filenames"
+              >
+                <span className="vesper-settings-toggle-knob" />
+              </button>
+            </div>
+
+            <div className="vesper-settings-row">
+              <div>
+                <div className="vesper-settings-row-title">Strip EXIF Data</div>
+                <div className="vesper-settings-row-copy">
+                  Remove metadata (location, camera info, timestamps) from images before uploading. Enabled by default for privacy.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setStripExif(!stripExif)}
+                className={stripExif ? 'vesper-settings-toggle vesper-settings-toggle-on' : 'vesper-settings-toggle'}
+                aria-pressed={stripExif}
+                aria-label="Strip EXIF Data"
+              >
+                <span className="vesper-settings-toggle-knob" />
+              </button>
+            </div>
           </div>
         </>
       )}

--- a/client/src/renderer/src/index.css
+++ b/client/src/renderer/src/index.css
@@ -4147,57 +4147,154 @@ select:focus-visible {
   cursor: pointer;
 }
 
-.vesper-composer-staged-files {
+/* --- Staged file attachment tray (Discord-style cards) --- */
+
+.vesper-staged-tray {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  padding: 0.65rem 0.75rem 0.4rem;
+  gap: 1rem;
+  padding: 1rem 0.75rem 0.5rem;
+  overflow-x: auto;
   border-bottom: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  scrollbar-width: thin;
 }
 
-.vesper-composer-staged-file {
-  display: inline-flex;
+.vesper-staged-card {
+  position: relative;
+  flex: 0 0 auto;
+  width: 200px;
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-bg-tertiary) 40%, transparent);
+  overflow: hidden;
+}
+
+.vesper-staged-card-actions {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 4px;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.vesper-staged-card:hover .vesper-staged-card-actions {
+  opacity: 1;
+}
+
+.vesper-staged-card-action {
+  display: flex;
   align-items: center;
-  gap: 0.4rem;
-  max-width: 16rem;
-  padding: 0.35rem 0.45rem 0.35rem 0.55rem;
-  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
-  border-radius: 0.7rem;
-  background: color-mix(in srgb, var(--color-bg-tertiary) 50%, transparent);
-  font-size: 0.78rem;
-  line-height: 1;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-bg-primary) 85%, transparent);
+  color: var(--color-text-faint);
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  transition: background-color 0.12s ease, color 0.12s ease;
 }
 
-.vesper-composer-staged-name {
+.vesper-staged-card-action:hover {
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+}
+
+.vesper-staged-card-action-delete:hover {
+  color: #f87171;
+}
+
+.vesper-staged-card-preview {
+  width: 100%;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--color-bg-secondary) 60%, transparent);
+}
+
+.vesper-staged-card-spoiler .vesper-staged-card-thumbnail {
+  filter: blur(24px) brightness(0.5);
+}
+
+.vesper-staged-card-spoiler-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.vesper-staged-card-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: filter 0.2s ease;
+}
+
+.vesper-staged-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-faintest);
+}
+
+.vesper-staged-card-name {
+  padding: 8px 10px;
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--color-text-secondary);
-  font-weight: 500;
 }
 
-.vesper-composer-staged-size {
-  color: var(--color-text-faint);
-  white-space: nowrap;
+.vesper-staged-card-action-active {
+  color: var(--color-accent-text, #c8a24e) !important;
 }
 
-.vesper-composer-staged-remove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.3rem;
-  height: 1.3rem;
-  border: 0;
-  border-radius: 0.4rem;
-  background: transparent;
+.vesper-staged-card-anon .vesper-staged-card-name {
+  font-style: italic;
   color: var(--color-text-faint);
+}
+
+/* Spoiler overlay on received file attachments */
+.vesper-file-spoiler-overlay {
+  position: relative;
+  display: block;
   cursor: pointer;
-  transition: background-color 0.14s ease, color 0.14s ease;
+  border: 0;
+  padding: 0;
+  background: none;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
-.vesper-composer-staged-remove:hover {
-  background: color-mix(in srgb, var(--color-bg-tertiary) 80%, transparent);
-  color: #fca5a5;
+.vesper-file-spoiler-overlay img {
+  filter: blur(28px) brightness(0.5);
+  transition: filter 0.2s ease;
+}
+
+.vesper-file-spoiler-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  pointer-events: none;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
 }
 
 .vesper-composer-controls {
@@ -4246,7 +4343,6 @@ select:focus-visible {
 
 .vesper-composer-icon-button:hover,
 .vesper-composer-send:hover {
-  background: color-mix(in srgb, var(--color-bg-tertiary) 78%, transparent);
   color: var(--color-text-primary);
 }
 
@@ -4314,6 +4410,10 @@ select:focus-visible {
 .vesper-slate-editable [data-slate-placeholder] {
   color: var(--color-text-faintest) !important;
   opacity: 1 !important;
+  top: calc(
+    (var(--vesper-composer-textarea-height) - var(--vesper-composer-line-height)) / 2
+  ) !important;
+  pointer-events: none;
 }
 
 /* Leaf decorations */
@@ -4338,17 +4438,21 @@ select:focus-visible {
 
 /* Inline void elements */
 .vesper-slate-inline-void {
-  display: inline-block;
+  display: inline;
   vertical-align: baseline;
   cursor: default;
   user-select: none;
 }
-.vesper-slate-emoji { display: inline; }
+.vesper-slate-emoji {
+  display: inline;
+  line-height: 0;
+}
 .vesper-slate-emoji img {
+  display: inline !important;
   height: 1.375em;
   width: 1.375em;
   object-fit: contain;
-  vertical-align: bottom;
+  vertical-align: -0.3em;
 }
 .vesper-slate-mention {
   background: var(--color-accent-bg, rgba(200, 162, 78, 0.15));

--- a/client/src/renderer/src/index.css
+++ b/client/src/renderer/src/index.css
@@ -4381,6 +4381,27 @@ select:focus-visible {
   overflow-x: auto;
 }
 
+/* Spoiler in sent messages */
+.vesper-spoiler {
+  border-radius: 3px;
+  cursor: pointer;
+  display: inline;
+  transition: background-color 0.1s ease;
+}
+.vesper-spoiler-hidden {
+  background: var(--color-text-primary, #e0e0e0);
+}
+.vesper-spoiler-hidden .vesper-spoiler-content {
+  opacity: 0;
+  user-select: none;
+}
+.vesper-spoiler-revealed {
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.06));
+}
+.vesper-spoiler-revealed .vesper-spoiler-content {
+  opacity: 1;
+}
+
 .vesper-composer-rich-markdown {
   color: inherit;
   min-width: 0;

--- a/client/src/renderer/src/index.css
+++ b/client/src/renderer/src/index.css
@@ -4288,34 +4288,97 @@ select:focus-visible {
   color: var(--color-text-faintest);
 }
 
-.vesper-composer-textarea-rich {
-  color: transparent;
-  caret-color: var(--color-text-primary);
-  font-family: var(--font-mono, 'SFMono-Regular', 'Menlo', monospace);
-  tab-size: 2;
-}
+/* --- Slate editor styles --- */
 
-.vesper-composer-rich-preview {
-  min-height: var(--vesper-composer-textarea-height);
+.vesper-slate-editable {
+  flex: 1;
   max-height: var(--vesper-composer-textarea-max-height);
-  overflow: auto;
-  display: flex;
-  align-items: flex-start;
+  border: 0;
+  background: transparent;
   box-sizing: border-box;
+  min-height: var(--vesper-composer-textarea-height);
   padding-block: calc(
     (var(--vesper-composer-textarea-height) - var(--vesper-composer-line-height)) / 2
   );
   padding-inline: 0 0.65rem;
   color: var(--color-text-primary);
+  outline: none;
   font-size: 0.92rem;
   line-height: var(--vesper-composer-line-height);
+  overflow-y: auto;
   word-break: break-word;
-  pointer-events: none;
-  scrollbar-width: none;
+  white-space: break-spaces;
+  caret-color: var(--color-text-primary);
 }
 
-.vesper-composer-rich-preview::-webkit-scrollbar {
-  display: none;
+.vesper-slate-editable [data-slate-placeholder] {
+  color: var(--color-text-faintest) !important;
+  opacity: 1 !important;
+}
+
+/* Leaf decorations */
+.vesper-slate-bold { font-weight: 700; }
+.vesper-slate-italic { font-style: italic; }
+.vesper-slate-underline { text-decoration: underline; }
+.vesper-slate-strikethrough { text-decoration: line-through; }
+.vesper-slate-inline-code {
+  background: var(--color-bg-tertiary);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+  font-family: var(--font-mono, 'SFMono-Regular', 'Menlo', monospace);
+  font-size: 85%;
+}
+.vesper-slate-spoiler-composer {
+  background: var(--color-bg-tertiary);
+  border-radius: 3px;
+  padding: 0 0.15em;
+}
+.vesper-slate-syntax-mark { color: var(--color-text-faintest); }
+.vesper-slate-link { color: var(--color-accent-text); text-decoration: underline; }
+
+/* Inline void elements */
+.vesper-slate-inline-void {
+  display: inline-block;
+  vertical-align: baseline;
+  cursor: default;
+  user-select: none;
+}
+.vesper-slate-emoji { display: inline; }
+.vesper-slate-emoji img {
+  height: 1.375em;
+  width: 1.375em;
+  object-fit: contain;
+  vertical-align: bottom;
+}
+.vesper-slate-mention {
+  background: var(--color-accent-bg, rgba(200, 162, 78, 0.15));
+  color: var(--color-accent-text, #c8a24e);
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 500;
+}
+.vesper-slate-channel-mention {
+  background: var(--color-accent-bg, rgba(200, 162, 78, 0.15));
+  color: var(--color-accent-text, #c8a24e);
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 500;
+}
+
+/* Block elements */
+.vesper-slate-blockquote {
+  border-left: 3px solid var(--color-accent, #c8a24e);
+  padding-left: 0.75rem;
+  margin: 0.25rem 0;
+}
+.vesper-slate-code-block {
+  background: var(--color-bg-tertiary);
+  border-radius: 4px;
+  padding: 0.5rem;
+  font-family: var(--font-mono, 'SFMono-Regular', 'Menlo', monospace);
+  font-size: 85%;
+  margin: 0.25rem 0;
+  overflow-x: auto;
 }
 
 .vesper-composer-rich-markdown {

--- a/client/src/renderer/src/index.css
+++ b/client/src/renderer/src/index.css
@@ -4469,6 +4469,13 @@ select:focus-visible {
   font-weight: 500;
 }
 
+.vesper-slate-blockquote-text {
+  color: var(--color-text-faint);
+  border-left: 3px solid var(--color-accent, #c8a24e);
+  padding-left: 0.5rem;
+  margin-left: 2px;
+}
+
 /* Block elements */
 .vesper-slate-blockquote {
   border-left: 3px solid var(--color-accent, #c8a24e);

--- a/client/src/renderer/src/pages/MainPage.tsx
+++ b/client/src/renderer/src/pages/MainPage.tsx
@@ -318,7 +318,6 @@ export default function MainPage(): React.JSX.Element {
   }, [activeChannelId, closeThread, selectedConversationId])
 
   useEffect(() => {
-    setThreadReply('')
     setReplyingTo(null)
   }, [activeThreadParentId, setReplyingTo])
 

--- a/client/src/renderer/src/pages/MainPage.tsx
+++ b/client/src/renderer/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useRef, useState, useCallback } from 'react'
 import { SendHorizonal, Star, X } from 'lucide-react'
 import Sidebar from '../components/layout/Sidebar'
 import Header from '../components/layout/Header'
@@ -6,6 +6,7 @@ import MessageList from '../components/chat/MessageList'
 import MessageInput from '../components/chat/MessageInput'
 import MessageItem from '../components/chat/MessageItem'
 import MessageFeed from '../components/chat/message/MessageFeed'
+import VesperEditor from '../components/chat/slate/VesperEditor'
 import { useServerStore } from '../stores/serverStore'
 import { useDmStore } from '../stores/dmStore'
 import { useUIStore } from '../stores/uiStore'
@@ -181,7 +182,6 @@ export default function MainPage(): React.JSX.Element {
     }
     return EMPTY_MESSAGES
   })
-  const [threadReply, setThreadReply] = useState('')
   const sawInitialSocketOpenRef = useRef(false)
   const [connectionState, setConnectionState] = useState(() => {
     const clientState = getRendererClient().getState()
@@ -322,19 +322,8 @@ export default function MainPage(): React.JSX.Element {
     setReplyingTo(null)
   }, [activeThreadParentId, setReplyingTo])
 
-  const submitThreadReply = (): void => {
-    const trimmed = threadReply.trim()
-    if (!trimmed) {
-      return
-    }
-
-    void sendThreadReply(trimmed)
-    setThreadReply('')
-  }
-
   const handleThreadSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
-    submitThreadReply()
   }
 
   const renderThreadPanel = (mobilePanel: boolean): React.JSX.Element | null => {
@@ -427,23 +416,18 @@ export default function MainPage(): React.JSX.Element {
               </button>
             </div>
           )}
-          <textarea
-            value={threadReply}
-            onChange={(event) => setThreadReply(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault()
-                submitThreadReply()
-              }
+          <VesperEditor
+            mode="compose"
+            onSubmit={(markdown) => {
+              const trimmed = markdown.trim()
+              if (trimmed) void sendThreadReply(trimmed)
             }}
             placeholder="Reply to thread"
-            rows={1}
-            className="vesper-thread-composer-textarea"
-            disabled={!activeThreadParentId}
+            autoFocus
           />
           <button
             type="submit"
-            disabled={!threadReply.trim() || !activeThreadParentId}
+            disabled={!activeThreadParentId}
             className="vesper-thread-composer-send"
           >
             <SendHorizonal className="w-4 h-4" />

--- a/client/src/renderer/src/stores/settingsStore.ts
+++ b/client/src/renderer/src/stores/settingsStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 import { getStoredValue, setStoredValue, writeStoredValue } from '../utils/localStorage'
 
 const LINK_PREVIEWS_STORAGE_KEY = 'linkPreviews'
+const ANON_FILENAMES_KEY = 'privacy:anonFilenames'
+const STRIP_EXIF_KEY = 'privacy:stripExif'
 
 function normalizeServerUrl(url: string): string {
   return url.trim().replace(/\/+$/, '')
@@ -21,13 +23,19 @@ function getInitialServerUrl(): string {
 interface SettingsState {
   serverUrl: string
   linkPreviewsEnabled: boolean
+  anonFilenames: boolean
+  stripExif: boolean
   setServerUrl: (url: string) => void
   setLinkPreviewsEnabled: (enabled: boolean) => void
+  setAnonFilenames: (enabled: boolean) => void
+  setStripExif: (enabled: boolean) => void
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
   serverUrl: getInitialServerUrl(),
   linkPreviewsEnabled: getStoredValue(LINK_PREVIEWS_STORAGE_KEY) === 'enabled',
+  anonFilenames: getStoredValue(ANON_FILENAMES_KEY) === 'enabled',
+  stripExif: getStoredValue(STRIP_EXIF_KEY) !== 'disabled', // on by default
 
   setServerUrl: (url) => {
     const normalized = normalizeServerUrl(url)
@@ -38,5 +46,15 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   setLinkPreviewsEnabled: (enabled) => {
     setStoredValue(LINK_PREVIEWS_STORAGE_KEY, enabled ? 'enabled' : 'disabled')
     set({ linkPreviewsEnabled: enabled })
+  },
+
+  setAnonFilenames: (enabled) => {
+    setStoredValue(ANON_FILENAMES_KEY, enabled ? 'enabled' : 'disabled')
+    set({ anonFilenames: enabled })
+  },
+
+  setStripExif: (enabled) => {
+    setStoredValue(STRIP_EXIF_KEY, enabled ? 'enabled' : 'disabled')
+    set({ stripExif: enabled })
   }
 }))

--- a/client/src/renderer/src/utils/stripExif.ts
+++ b/client/src/renderer/src/utils/stripExif.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip EXIF and other metadata from an image file by re-encoding
+ * it through a canvas. The canvas drawImage + toBlob pipeline
+ * produces a clean image with no metadata.
+ *
+ * Preserves the original dimensions and uses the same MIME type.
+ * Falls back to the original file if re-encoding fails.
+ */
+export async function stripExifData(file: File): Promise<File> {
+  // Only strip from JPEG and WebP — PNG/GIF don't typically have EXIF
+  if (!file.type.match(/^image\/(jpeg|webp)$/)) {
+    return file
+  }
+
+  try {
+    const bitmap = await createImageBitmap(file)
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return file
+
+    ctx.drawImage(bitmap, 0, 0)
+    bitmap.close()
+
+    const blob = await canvas.convertToBlob({
+      type: file.type,
+      quality: file.type === 'image/jpeg' ? 0.92 : undefined,
+    })
+
+    return new File([blob], file.name, { type: file.type })
+  } catch {
+    return file
+  }
+}

--- a/client/src/renderer/src/utils/twemoji.ts
+++ b/client/src/renderer/src/utils/twemoji.ts
@@ -1,31 +1,27 @@
 // Self-hosted twemoji SVGs served from public/twemoji/ (copied from twemoji-emojis on postinstall)
 const TWEMOJI_BASE = '/twemoji'
 
-// Codepoints below this threshold that appear alone are "text-presentation-by-default"
-// and need FE0F to map to the correct twemoji filename (e.g. red heart 2764-fe0f).
-const TEXT_PRESENTATION_THRESHOLD = 0x1f000
-
 /**
- * Convert a Unicode emoji string to hyphen-joined hex codepoints.
- * Handles surrogates, ZWJ sequences, and FE0F variation selector stripping.
+ * Convert a Unicode emoji string to hyphen-joined hex codepoints matching
+ * the twemoji-emojis v14 filename convention:
  *
- *   "😄"        → "1f604"
- *   "🇺🇸"      → "1f1fa-1f1f8"
- *   "❤️"        → "2764-fe0f"
- *   "👨‍👩‍👧"  → "1f468-200d-1f469-200d-1f467"
+ *   - Standalone emojis: FE0F stripped entirely ("❤️" → "2764")
+ *   - ZWJ sequences: FE0F kept where present ("❤️‍🔥" → "2764-fe0f-200d-1f525")
+ *   - Skin tones: kept as-is ("👍🏽" → "1f44d-1f3fd")
  */
 export function emojiToCodepoints(emoji: string): string {
   const raw = [...emoji].map((ch) => ch.codePointAt(0)!)
 
-  // Strip FE0F
-  const stripped = raw.filter((cp) => cp !== 0xfe0f)
+  // Check if this is a multi-codepoint sequence (has ZWJ, skin tones, flags, etc.)
+  const hasZwj = raw.includes(0x200d)
 
-  // If stripping FE0F left a single codepoint below the threshold,
-  // the file needs FE0F (text-presentation-by-default characters like ❤️).
-  if (stripped.length === 1 && stripped[0] < TEXT_PRESENTATION_THRESHOLD) {
-    return stripped[0].toString(16) + '-fe0f'
+  if (hasZwj) {
+    // ZWJ sequences: keep FE0F in place — filenames retain it
+    return raw.map((cp) => cp.toString(16)).join('-')
   }
 
+  // Non-ZWJ: strip FE0F entirely — filenames never have it for standalone emojis
+  const stripped = raw.filter((cp) => cp !== 0xfe0f)
   const points = stripped.length > 0 ? stripped : raw
   return points.map((cp) => cp.toString(16)).join('-')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "slate": "^0.124.0",
+        "slate-history": "^0.113.1",
+        "slate-react": "^0.124.0",
         "tailwindcss": "^4.2.1",
         "zustand": "^5.0.11"
       },
@@ -4654,11 +4657,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "client/node_modules/lodash": {
-      "version": "4.17.23",
-      "dev": true,
-      "license": "MIT"
-    },
     "client/node_modules/lodash-es": {
       "version": "4.17.23",
       "license": "MIT"
@@ -7931,6 +7929,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@noble/ciphers": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
@@ -8243,6 +8247,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -8482,6 +8492,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/download": {
@@ -8975,6 +8998,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw==",
+      "license": "MIT"
+    },
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -8997,6 +9026,15 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9075,6 +9113,12 @@
       "dependencies": {
         "json-buffer": "3.0.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
@@ -9450,6 +9494,15 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -9490,6 +9543,63 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/slate": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.124.0.tgz",
+      "integrity": "sha512-yhtJ0MSV+Z63UTaZtGZDp1goO9XZb5VGER9bmwX+38yJUb7nijPkYEcxD5mpezsSLqL6NedUb4wyvoZa+HDWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/slate-dom": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.124.0.tgz",
+      "integrity": "sha512-dPabNlzo67xWRNFT5HtSc0M/F9mfiQSnjJAEx0Uzk7oC++WaRuBy897F+rNzfvM+zH9exMc3hsTMtM7jGDhIiQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.121.0"
+      }
+    },
+    "node_modules/slate-history": {
+      "version": "0.113.1",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.113.1.tgz",
+      "integrity": "sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      },
+      "peerDependencies": {
+        "slate": ">=0.65.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.124.0.tgz",
+      "integrity": "sha512-NLN6ME64ChOgJtiVTKwISS1sI/Y8/qN1cwmDTZM9AQJCl+jR3XNCvDsKNrW0kJU+1G3NgIGaYoVWhgIVEIL+Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.121.0",
+        "slate-dom": ">=0.119.1"
       }
     },
     "node_modules/sort-keys": {
@@ -9616,6 +9726,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",

--- a/server/lib/vesper/servers.ex
+++ b/server/lib/vesper/servers.ex
@@ -1380,7 +1380,9 @@ defmodule Vesper.Servers do
       |> Enum.reduce({[], []}, fn {{id, position}, idx}, {params, fragments} ->
         id_idx = idx * 2 + 1
         pos_idx = idx * 2 + 2
-        {params ++ [Ecto.UUID.dump!(id), position], fragments ++ ["($#{id_idx}::uuid, $#{pos_idx}::integer)"]}
+
+        {params ++ [Ecto.UUID.dump!(id), position],
+         fragments ++ ["($#{id_idx}::uuid, $#{pos_idx}::integer)"]}
       end)
 
     values = Enum.join(placeholders, ", ")


### PR DESCRIPTION
## Summary

Replaces the textarea + overlay-based rich preview with a Slate.js contentEditable editor, modeled on Discord's architecture.

### Rich Editor
- **Live markdown decorations**: `**bold**`, `*italic*`, `~~strike~~`, `` `code` ``, `||spoiler||`, URLs — all render visually in the composer with dimmed syntax markers
- **Inline void nodes**: emoji (Twemoji SVGs), @mentions (styled chips), #channels insert as atomic non-editable elements via autocomplete
- **Block elements**: `> ` creates blockquotes with accent border, ``` enters/exits code blocks
- **Native browser caret** — no custom caret tricks
- **Unified editor**: same VesperEditor component for main composer, inline message editing, and thread replies

### Spoiler Support
- `||text||` in composer renders with distinct background
- Sent messages: click-to-reveal with blur effect
- File attachments: SPOILER_ prefix triggers blur on received images

### File Attachments
- Discord-style card tray with image/video thumbnails
- Anonymous filename toggle (glasses icon, 16-char random name)
- Spoiler toggle (eye icon, prepends SPOILER_ to filename)
- Hover action buttons, horizontal scroll

### Other
- Fixed twemoji codepoint conversion (FE0F handling for ZWJ sequences)
- @mention autocomplete triggers immediately on `@`
- Members auto-fetched on composer mount
- 4000 character limit
- E2E helpers updated for contentEditable

## Test plan
- [ ] Type and send messages — verify encryption still works
- [ ] Markdown formatting in composer (bold, italic, etc.)
- [ ] @mention autocomplete — insert void chip, serialize to `<@id>`
- [ ] :emoji: autocomplete — insert Twemoji inline
- [ ] Emoji picker — inserts inline, not new line
- [ ] Edit existing message via VesperEditor
- [ ] Thread reply via VesperEditor
- [ ] File upload with thumbnail preview
- [ ] Anonymous + spoiler file toggles
- [ ] `||spoiler||` click-to-reveal in sent messages
- [ ] SPOILER_ images blur on receive

🤖 Generated with [Claude Code](https://claude.com/claude-code)