### PR TITLE
Fix RC recovery contention, room ordering, TURN, and clustering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,9 @@ REGISTRATION_MODE=closed
 # This deliberately short placeholder makes production startup fail until replaced.
 METRICS_TOKEN=change-me
 
-# DNS query for clustering in multi-node deployments
-# DNS_CLUSTER_QUERY=
+# DNS A/AAAA query for clustering in multi-node deployments (not SRV).
+# Vesper normalizes it to an absolute name to avoid search-domain ambiguity.
+# DNS_CLUSTER_QUERY=vesper-apps.internal
 
 # =============================================================================
 # CORS & Origins

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -43,7 +43,8 @@ jobs:
               'server/' 'client/' 'sdk/' \
               'Dockerfile*' '**/Dockerfile*' \
               '.dockerignore' '**/dockerignore' \
-              'docker-compose.yml' \
+              'docker-compose.yml' 'turnserver.conf' \
+              'scripts/test-turn-policy.sh' 'scripts/test-dns-cluster.sh' \
               '.github/workflows/test-docker.yml' \
             | grep -qvE '\.md$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -64,16 +65,52 @@ jobs:
       - name: Build web client image
         run: docker build -f client/Dockerfile.web -t vesper-web-test .
 
+      - name: Test absolute DNS A/AAAA clustering
+        env:
+          APP_IMAGE: vesper-app-test
+          ARTIFACT_DIR: ${{ runner.temp }}/dns-cluster
+        run: ./scripts/test-dns-cluster.sh
+
+      - name: Upload DNS cluster evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dns-cluster-evidence
+          path: ${{ runner.temp }}/dns-cluster
+          retention-days: 7
+
+  turn-policy:
+    needs: docker-changes
+    if: needs.docker-changes.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Test TURN relay peer policy
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/turn-policy
+        run: ./scripts/test-turn-policy.sh
+
+      - name: Upload TURN policy evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: turn-policy-evidence
+          path: ${{ runner.temp }}/turn-policy
+          retention-days: 7
+
   # Gate job — branch protection should require this check.
   docker-checks:
     if: always()
-    needs: [docker-changes, docker-build]
+    needs: [docker-changes, docker-build, turn-policy]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate result
         run: |
-          if [ "${{ needs.docker-build.result }}" = "failure" ] || [ "${{ needs.docker-build.result }}" = "cancelled" ]; then
-            echo "Docker build failed or was cancelled"
-            exit 1
-          fi
-          echo "Docker build passed or was skipped (no relevant changes)"
+          for result in "${{ needs.docker-changes.result }}" "${{ needs.docker-build.result }}" "${{ needs.turn-policy.result }}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "Docker or TURN policy validation failed or was cancelled"
+              exit 1
+            fi
+          done
+          echo "Docker and TURN policy validation passed or was skipped (no relevant changes)"

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ All variables are set in `.env` (loaded by Docker Compose) or exported in the sh
 | `APP_PORT` | `4000` | No | External port the API server listens on |
 | `PHX_SERVER` | — | No | Set to `true` to start the HTTP server (set automatically in Docker) |
 | `JWT_SECRET` | same as `SECRET_KEY_BASE` | No | Separate secret for JWT signing, if desired |
-| `DNS_CLUSTER_QUERY` | — | No | DNS query for clustering in multi-node deployments |
+| `DNS_CLUSTER_QUERY` | — | No | DNS A/AAAA query for replica discovery (not SRV); Vesper normalizes it to an absolute name |
 | `METRICS_TOKEN` | — | **Yes** (prod) | Bearer token for `/metrics`; must contain at least 32 bytes. |
 | `REGISTRATION_MODE` | `closed` | No | `closed`, `open`, or `invite_only`. Production defaults closed. |
 | `REGISTRATION_INVITE_SECRET` | — | **Yes** for `invite_only` | Shared registration secret compared in constant time. |

--- a/doc/configuration-guide.md
+++ b/doc/configuration-guide.md
@@ -65,7 +65,7 @@ Set to `true` or `1` to enable IPv6 socket options for database connections.
 
 ### DNS_CLUSTER_QUERY
 
-Optional DNS SRV record for Erlang clustering in multi-node deployments. Most deployments can ignore this.
+Optional DNS **A/AAAA** query used to discover Erlang nodes in a multi-replica deployment. This is not an SRV lookup. Vesper trims the value and appends a trailing dot when needed, making the query absolute and avoiding resolver search-domain ambiguity. Every returned address must run the same release node basename and cookie, with `RELEASE_NODE` named at its discoverable IP (for example `vesper@10.0.0.12`). Most single-replica deployments should leave this unset.
 
 ### POOL_SIZE
 
@@ -85,12 +85,12 @@ Controls which origins can make cross-origin requests.
 
 | Value | Behavior |
 |-------|----------|
-| (unset) | Allows all origins (`*`). Logs a warning. |
-| `*` | Allows all origins. No warning. |
+| (unset or empty) | Production startup fails closed. |
+| `*` | Production startup fails closed. |
 | `https://chat.example.com` | Single allowed origin |
-| `https://a.example.com,https://b.example.com` | Comma-separated list |
+| `https://a.example.com,https://b.example.com` | Comma-separated explicit origins |
 
-The WebSocket `check_origin` setting follows the same logic: when `CORS_ORIGIN` is unset or `*`, origin checking is disabled.
+The WebSocket `check_origin` setting uses the same explicit origin set. Packaged desktop clients may require their concrete `file://` origin or `null`, depending on the target platform; add only the value observed for the release artifact.
 
 Allowed methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`.
 Allowed headers: `authorization`, `content-type`.
@@ -104,11 +104,11 @@ Allowed headers: `authorization`, `content-type`.
 TURN server URL. When set, the voice config endpoint includes it in the ICE server list alongside the default Google STUN server.
 
 ```
-TURN_SERVER_URL=turn:coturn:3478
+TURN_SERVER_URL=turn:turn.example.com:3478
 TURN_SERVER_URL=turns:turn.example.com:443?transport=tcp
 ```
 
-When unset, only the public Google STUN server is advertised. Voice calls will fail for clients behind symmetric NATs without a TURN server.
+The value is delivered to remote clients, so a Compose-only hostname such as `turn:coturn:3478` is invalid. A `turns:` URL also requires a separately configured certificate and TLS listener. When unset, only the public Google STUN server is advertised. Voice calls will fail for clients behind symmetric NATs without a TURN server.
 
 ### TURN_USERNAME
 

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -148,6 +148,8 @@ Do not use `mix ecto.rollback` as production rollback. Once new writers have emi
 
 For multiple application replicas, remove the per-container migration command and run `bin/vesper eval 'Vesper.Release.migrate()'` once as a deployment job while old writers are stopped. Keep `RUN_MIGRATIONS_ON_START=false` on replicas; health remains red if their release sees a pending migration.
 
+Set `DNS_CLUSTER_QUERY` to a DNS A/AAAA name that returns every application replica; it is not an SRV record. Vesper normalizes the query to an absolute name so resolver search domains cannot change its meaning. All replicas must share `RELEASE_COOKIE` and the same `RELEASE_NODE` basename, while each node name uses its own discoverable IP (for example `vesper@10.0.0.12`). Verify `Node.list()` from every replica before relying on cross-node Phoenix PubSub.
+
 The four-worker soak proves multi-process clients against one application/database deployment. It is not multi-region or database-failover evidence. Validate node loss, load-balancer behavior, PostgreSQL failover, and upload-storage consistency in your own canary before calling that topology supported.
 
 ## Monitoring and backups

--- a/scripts/test-dns-cluster.sh
+++ b/scripts/test-dns-cluster.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_IMAGE="${APP_IMAGE:-vesper-app-test}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$(mktemp -d /tmp/vesper-dns-cluster.XXXXXX)}"
+mkdir -p "$ARTIFACT_DIR"
+
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-$(
+  awk '
+    /^  db:$/ { in_db = 1; next }
+    in_db && /^[[:space:]]+image:/ { print $2; exit }
+  ' "$ROOT/docker-compose.yml"
+)}"
+
+if [[ -z "$POSTGRES_IMAGE" || "$POSTGRES_IMAGE" != *@sha256:* ]]; then
+  echo "Could not resolve a digest-pinned PostgreSQL image from docker-compose.yml" >&2
+  exit 1
+fi
+
+suffix="${GITHUB_RUN_ID:-$$}-${RANDOM}"
+network="vesper-dns-cluster-$suffix"
+db="vesper-dns-cluster-db-$suffix"
+app1="vesper-dns-cluster-app1-$suffix"
+app2="vesper-dns-cluster-app2-$suffix"
+db_password="$(openssl rand -hex 32)"
+secret="$(openssl rand -hex 64)"
+metrics_token="$(openssl rand -hex 32)"
+turn_password="$(openssl rand -hex 32)"
+cookie="$(openssl rand -hex 32)"
+
+cleanup() {
+  docker rm -f "$app1" "$app2" "$db" >/dev/null 2>&1 || true
+  docker network rm "$network" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+common_env=(
+  -e "DATABASE_URL=ecto://vesper:$db_password@11.203.0.10/vesper_cluster"
+  -e "SECRET_KEY_BASE=$secret"
+  -e "PHX_HOST=cluster.invalid"
+  -e "CORS_ORIGIN=https://cluster.invalid"
+  -e "METRICS_TOKEN=$metrics_token"
+  -e "TURN_SERVER_URL=turn:turn.cluster.invalid:3478"
+  -e "TURN_USERNAME=vesper"
+  -e "TURN_PASSWORD=$turn_password"
+  -e "REGISTRATION_MODE=closed"
+  -e "RUN_MIGRATIONS_ON_START=false"
+)
+
+wait_for_postgres() {
+  for _ in $(seq 1 30); do
+    if docker exec "$db" pg_isready -U vesper -d vesper_cluster >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "$db" >&2 2>&1 || true
+  return 1
+}
+
+wait_for_health() {
+  local container="$1"
+  for _ in $(seq 1 60); do
+    if docker exec "$container" curl -fsS http://localhost:4000/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "$container" >&2 2>&1 || true
+  return 1
+}
+
+node_list() {
+  local container="$1"
+  local node="$2"
+  docker exec -e "RELEASE_NODE=$node" -e RELEASE_DISTRIBUTION=name \
+    -e "RELEASE_COOKIE=$cookie" "$container" \
+    bin/vesper rpc 'IO.puts(Node.list() |> Enum.map(&Atom.to_string/1) |> Enum.sort() |> Enum.join(","))'
+}
+
+echo "Testing DNS A/AAAA clustering with $APP_IMAGE"
+docker image inspect "$APP_IMAGE" >/dev/null
+docker pull "$POSTGRES_IMAGE" >/dev/null
+
+docker network create --subnet 11.203.0.0/24 "$network" >/dev/null
+docker run -d --name "$db" --network "$network" --ip 11.203.0.10 \
+  -e POSTGRES_USER=vesper -e "POSTGRES_PASSWORD=$db_password" \
+  -e POSTGRES_DB=vesper_cluster "$POSTGRES_IMAGE" >/dev/null
+wait_for_postgres
+
+docker run --rm --network "$network" "${common_env[@]}" \
+  -e RELEASE_DISTRIBUTION=none --entrypoint /bin/sh "$APP_IMAGE" \
+  -c "bin/vesper eval 'Vesper.Release.migrate()'" >"$ARTIFACT_DIR/migration.log" 2>&1
+
+docker run -d --name "$app1" --network "$network" --ip 11.203.0.21 \
+  --network-alias vesper-apps "${common_env[@]}" \
+  -e DNS_CLUSTER_QUERY=vesper-apps -e RELEASE_DISTRIBUTION=name \
+  -e RELEASE_NODE=vesper@11.203.0.21 -e "RELEASE_COOKIE=$cookie" \
+  "$APP_IMAGE" >/dev/null
+docker run -d --name "$app2" --network "$network" --ip 11.203.0.22 \
+  --network-alias vesper-apps "${common_env[@]}" \
+  -e DNS_CLUSTER_QUERY=vesper-apps -e RELEASE_DISTRIBUTION=name \
+  -e RELEASE_NODE=vesper@11.203.0.22 -e "RELEASE_COOKIE=$cookie" \
+  "$APP_IMAGE" >/dev/null
+
+wait_for_health "$app1"
+wait_for_health "$app2"
+
+docker logs "$app1" >"$ARTIFACT_DIR/app1.log" 2>&1
+docker logs "$app2" >"$ARTIFACT_DIR/app2.log" 2>&1
+
+normalized_query="$(docker exec -e RELEASE_NODE=vesper@11.203.0.21 \
+  -e RELEASE_DISTRIBUTION=name -e "RELEASE_COOKIE=$cookie" "$app1" \
+  bin/vesper rpc 'IO.puts(Application.fetch_env!(:vesper, :dns_cluster_query))' | tail -n 1)"
+if [[ "$normalized_query" != "vesper-apps." ]]; then
+  echo "DNS_CLUSTER_QUERY was not normalized to an absolute name: $normalized_query" >&2
+  exit 1
+fi
+
+for _ in $(seq 1 30); do
+  list1="$(node_list "$app1" vesper@11.203.0.21 | tail -n 1)"
+  list2="$(node_list "$app2" vesper@11.203.0.22 | tail -n 1)"
+  if [[ ",$list1," == *",vesper@11.203.0.22,"* && ",$list2," == *",vesper@11.203.0.21,"* ]]; then
+    printf 'normalized_query=%s\napp1_nodes=%s\napp2_nodes=%s\n' \
+      "$normalized_query" "$list1" "$list2" | tee "$ARTIFACT_DIR/result.txt"
+    echo "DNS cluster passed: both nodes discovered each other through an absolute A/AAAA query"
+    echo "Evidence: $ARTIFACT_DIR"
+    exit 0
+  fi
+  sleep 1
+done
+
+printf 'app1_nodes=%s\napp2_nodes=%s\n' "$list1" "$list2" >"$ARTIFACT_DIR/result.txt"
+echo "Application nodes did not form a bidirectional cluster" >&2
+exit 1

--- a/scripts/test-turn-policy.sh
+++ b/scripts/test-turn-policy.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="$ROOT/turnserver.conf"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$(mktemp -d /tmp/vesper-turn-policy.XXXXXX)}"
+mkdir -p "$ARTIFACT_DIR"
+
+TURN_IMAGE="${TURN_IMAGE:-$(
+  awk '
+    /^  coturn:$/ { in_coturn = 1; next }
+    in_coturn && /^[[:space:]]+image:/ { print $2; exit }
+  ' "$ROOT/docker-compose.yml"
+)}"
+
+if [[ -z "$TURN_IMAGE" || "$TURN_IMAGE" != *@sha256:* ]]; then
+  echo "Could not resolve a digest-pinned coturn image from docker-compose.yml" >&2
+  exit 1
+fi
+
+suffix="${GITHUB_RUN_ID:-$$}-${RANDOM}"
+v4_network="vesper-turn-policy-v4-$suffix"
+v6_network="vesper-turn-policy-v6-$suffix"
+v4_server="vesper-turn-policy-v4-server-$suffix"
+v6_server="vesper-turn-policy-v6-server-$suffix"
+password="$(openssl rand -hex 32)"
+transient_containers=()
+
+cleanup() {
+  docker rm -f "$v4_server" "$v6_server" "${transient_containers[@]}" >/dev/null 2>&1 || true
+  docker network rm "$v4_network" "$v6_network" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_server() {
+  local container="$1"
+  for _ in $(seq 1 30); do
+    if [[ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || true)" == "true" ]] &&
+       docker logs "$container" 2>&1 | grep -F 'listener opened on' >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  docker logs "$container" >&2 2>&1 || true
+  echo "TURN server $container did not become ready" >&2
+  return 1
+}
+
+assert_config_parsed() {
+  local container="$1"
+  local log="$ARTIFACT_DIR/config-parse.log"
+  docker logs "$container" >"$log" 2>&1
+
+  if grep -Eq 'Bad configuration format|option is deprecated|ERROR: tls-listening-port' "$log"; then
+    echo "coturn reported a malformed, deprecated, or inconsistent setting" >&2
+    grep -E 'Bad configuration format|option is deprecated|ERROR: tls-listening-port' "$log" >&2
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    local value="${line#denied-peer-ip=}"
+    if ! grep -Fq "Black listing: $value" "$log"; then
+      echo "coturn did not confirm parsing denied-peer-ip=$value" >&2
+      return 1
+    fi
+  done < <(grep '^denied-peer-ip=' "$CONFIG")
+
+  while IFS= read -r line; do
+    local value="${line#allowed-peer-ip=}"
+    if ! grep -Fq "White listing: $value" "$log"; then
+      echo "coturn did not confirm parsing allowed-peer-ip=$value" >&2
+      return 1
+    fi
+  done < <(grep '^allowed-peer-ip=' "$CONFIG")
+}
+
+run_positive_relay() {
+  local network="$1"
+  local server_ip="$2"
+  local family_flag="$3"
+  local label="$4"
+  local log="$ARTIFACT_DIR/allow-$label.log"
+  local client="vesper-turn-policy-allow-$label-$suffix"
+  local -a family_args=()
+  [[ -n "$family_flag" ]] && family_args+=("$family_flag")
+  transient_containers+=("$client")
+
+  set +e
+  timeout 60 docker run --rm --name "$client" --network "$network" \
+    --entrypoint turnutils_uclient "$TURN_IMAGE" \
+    -u vesper -w "$password" -p 3478 "${family_args[@]}" -y -n 10 "$server_ip" >"$log" 2>&1
+  local rc=$?
+  set -e
+  docker rm -f "$client" >/dev/null 2>&1 || true
+  if [[ $rc -ne 0 ]]; then
+    cat "$log" >&2
+    return 1
+  fi
+
+  grep -Eq 'tot_recv_msgs=40|tot_recv_msgs=4[0-9]' "$log"
+  grep -Fq 'Total lost packets 0' "$log"
+}
+
+expect_peer_denied() {
+  local container="$1"
+  local network="$2"
+  local server_ip="$3"
+  local peer_ip="$4"
+  local family_flag="$5"
+  local label="$6"
+  local client_log="$ARTIFACT_DIR/deny-$label-client.log"
+  local server_log="$ARTIFACT_DIR/deny-$label-server.log"
+  local client="vesper-turn-policy-deny-$label-$suffix"
+  local -a family_args=()
+  [[ -n "$family_flag" ]] && family_args+=("$family_flag")
+  transient_containers+=("$client")
+
+  set +e
+  timeout 20 docker run --rm --name "$client" --network "$network" --entrypoint turnutils_uclient "$TURN_IMAGE" \
+    -u vesper -w "$password" -p 3478 "${family_args[@]}" -c -n 1 \
+    -e "$peer_ip" -r 9999 "$server_ip" >"$client_log" 2>&1
+  local rc=$?
+  set -e
+  docker rm -f "$client" >/dev/null 2>&1 || true
+
+  if [[ $rc -eq 0 ]]; then
+    echo "coturn unexpectedly permitted peer $peer_ip" >&2
+    return 1
+  fi
+
+  for _ in $(seq 1 10); do
+    docker logs "$container" >"$server_log" 2>&1
+    if grep -F "A peer IP $peer_ip denied" "$server_log" >/dev/null; then
+      grep -Fq 'error 403: Forbidden IP' "$server_log"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "coturn did not emit an explicit denial for $peer_ip" >&2
+  return 1
+}
+
+echo "Testing TURN policy with $TURN_IMAGE"
+docker pull "$TURN_IMAGE" >/dev/null
+
+docker network create --subnet 11.201.0.0/24 "$v4_network" >/dev/null
+docker run -d --name "$v4_server" --network "$v4_network" --ip 11.201.0.2 \
+  -v "$CONFIG:/etc/coturn/turnserver.conf:ro" "$TURN_IMAGE" \
+  -c /etc/coturn/turnserver.conf --lt-cred-mech --realm=turn-policy.invalid \
+  --user="vesper:$password" --external-ip=11.201.0.2 \
+  --listening-ip=11.201.0.2 --relay-ip=11.201.0.2 >/dev/null
+wait_for_server "$v4_server"
+assert_config_parsed "$v4_server"
+run_positive_relay "$v4_network" 11.201.0.2 '' ipv4
+expect_peer_denied "$v4_server" "$v4_network" 11.201.0.2 10.0.0.1 '' private-ipv4
+expect_peer_denied "$v4_server" "$v4_network" 11.201.0.2 203.0.113.9 '' special-ipv4
+
+# 2001:3::/32 is a globally reachable exception inside the otherwise denied
+# 2001::/23 IETF assignments block, so this positive relay also proves that
+# coturn applies the narrow static allowance before the broad static denial.
+docker network create --ipv6 --subnet 11.202.0.0/24 \
+  --subnet 2001:3:ffff:201::/64 "$v6_network" >/dev/null
+docker run -d --name "$v6_server" --network "$v6_network" \
+  --ip 11.202.0.2 --ip6 2001:3:ffff:201::2 \
+  -v "$CONFIG:/etc/coturn/turnserver.conf:ro" "$TURN_IMAGE" \
+  -c /etc/coturn/turnserver.conf --lt-cred-mech --realm=turn-policy.invalid \
+  --user="vesper:$password" --external-ip=2001:3:ffff:201::2 \
+  --listening-ip=2001:3:ffff:201::2 --relay-ip=2001:3:ffff:201::2 >/dev/null
+wait_for_server "$v6_server"
+run_positive_relay "$v6_network" 2001:3:ffff:201::2 -x ipv6-allowed-exception
+expect_peer_denied "$v6_server" "$v6_network" 2001:3:ffff:201::2 fd00::1 -x ula-ipv6
+expect_peer_denied "$v6_server" "$v6_network" 2001:3:ffff:201::2 64:ff9b::a00:1 -x nat64-private-ipv4
+expect_peer_denied "$v6_server" "$v6_network" 2001:3:ffff:201::2 ::ffff:10.0.0.1 -x mapped-private-ipv4
+
+echo "TURN policy passed: public IPv4/IPv6 relay works and private/special peers fail with 403"
+echo "Evidence: $ARTIFACT_DIR"

--- a/sdk/src/client/encryptedChat.ts
+++ b/sdk/src/client/encryptedChat.ts
@@ -108,6 +108,8 @@ const HISTORY_BUNDLE_POLL_MS = 200
 const MAX_MESSAGES_PER_SCOPE = 200
 const MAX_HISTORY_AUTHORIZATION_ROWS = 10_000
 const MAX_SCOPE_RECOVERY_PACKAGE_BYTES = 262_144
+const SCOPE_RECOVERY_PACKAGE_PUBLISH_QUIET_MS = 2_000
+const SCOPE_RECOVERY_PACKAGE_PUBLISH_MAX_DELAY_MS = 30_000
 const MAX_PERSISTED_ROOM_KEY_EPOCHS = 8
 const SCOPE_RECOVERY_PACKAGE_VERSION = 1
 const DECRYPTION_PLACEHOLDER = '[Encrypted message unavailable]'
@@ -765,6 +767,8 @@ export class VesperEncryptedChat {
   private readonly pendingRepairFetches = new Map<string, Promise<void>>()
   private readonly lastRepairFetchAt = new Map<string, number>()
   private readonly recoveryPackagePublishes = new Map<string, Promise<void>>()
+  private readonly recoveryPackageRepublishRequested = new Set<string>()
+  private readonly recoveryPackageLastRequestedAt = new Map<string, number>()
   private readonly importedRecoveryPackageCursors = new Map<string, number>()
   private readonly importedRecoveryPackageFingerprints = new Map<string, string>()
   private readonly roomCrypto = new RoomCryptoState()
@@ -2802,6 +2806,96 @@ export class VesperEncryptedChat {
     }
   }
 
+  private async processLiveMessageInRoomOrder(
+    scope: EncryptedScope,
+    rawMessage: VesperMessage
+  ): Promise<ProcessedScopeMessage> {
+    const logicalScopeId = this.resolveRoomId(scope)
+    const existing =
+      this.scopeMessages.get(scope.id) ??
+      this.scopeMessages.get(logicalScopeId) ??
+      await this.loadProcessedCachedMessages(logicalScopeId)
+    const roomSeq = typeof rawMessage.room_seq === 'number' ? rawMessage.room_seq : null
+    const highestAppliedSeq = highestRoomSeq(existing)
+    const alreadyApplied = existing.find((message) => message.id === rawMessage.id) ?? null
+
+    if (alreadyApplied && roomSeq != null && roomSeq <= (highestAppliedSeq ?? 0)) {
+      return alreadyApplied
+    }
+
+    // Distributed PubSub preserves delivery but does not guarantee that
+    // broadcasts emitted by different application nodes arrive in room order.
+    // MLS sender ratchets are one-shot, so processing room_seq N before a
+    // missing earlier ciphertext can make that earlier message permanently
+    // undecryptable. A gap turns the live event into a wake-up signal: replay
+    // the committed room delta, which is sorted by room_seq, before exposing it.
+    if (roomSeq != null && roomSeq > (highestAppliedSeq ?? 0) + 1) {
+      let replayedMessages = existing
+      let replayAfterSeq = highestAppliedSeq ?? 0
+      let initialWindow = highestAppliedSeq == null
+
+      while (replayAfterSeq < roomSeq) {
+        const delta = initialWindow
+          ? await this.fetchInitialScopeWindow(scope, MAX_MESSAGES_PER_SCOPE)
+          : await this.fetchIncrementalScopeDelta(
+              scope,
+              MAX_MESSAGES_PER_SCOPE,
+              replayAfterSeq
+            )
+        initialWindow = false
+
+        const applied = await this.applyScopeSyncDelta(
+          scope,
+          replayedMessages,
+          delta.messages,
+          delta.events
+        )
+        replayedMessages = await this.retryFailedRoomApplicationMessages(
+          scope,
+          applied.messages
+        )
+        this.scopeMessages.set(scope.id, replayedMessages)
+
+        const replayed = replayedMessages.find((message) => message.id === rawMessage.id)
+        if (replayed) {
+          if (replayed.decryptionFailed) {
+            throw new Error(
+              `Ordered replay could not decrypt room ${logicalScopeId} sequence ${roomSeq}`
+            )
+          }
+          return replayed
+        }
+
+        const replayedRoomSeqs = [
+          ...delta.messages.map((message) => message.room_seq),
+          ...delta.events.map((event) => event.roomSeq)
+        ].filter((seq): seq is number => typeof seq === 'number')
+        const nextReplayAfterSeq = Math.max(replayAfterSeq, ...replayedRoomSeqs)
+        if (nextReplayAfterSeq === replayAfterSeq) {
+          break
+        }
+        replayAfterSeq = nextReplayAfterSeq
+        if (!delta.hasMore) {
+          break
+        }
+      }
+
+      // Never consume a one-shot MLS ratchet when durable replay could not
+      // establish that every prior room activity has been applied. A later
+      // sync/reconnect can retry from committed state; speculative processing
+      // here would make the missing ciphertext permanently undecryptable.
+      if (replayAfterSeq !== roomSeq - 1) {
+        throw new Error(
+          `Could not replay room ${logicalScopeId} through sequence ${roomSeq - 1}`
+        )
+      }
+    }
+
+    const message = await this.processIncomingMessage(scope, rawMessage)
+    this.upsertScopeMessage(scope.id, message)
+    return message
+  }
+
   private async handleScopeEvent(
     scope: EncryptedScope,
     event: string,
@@ -2834,8 +2928,10 @@ export class VesperEncryptedChat {
     }
 
     if (event === 'new_message') {
-      const message = await this.processIncomingMessage(scope, payload as unknown as VesperMessage)
-      this.upsertScopeMessage(scope.id, message)
+      const message = await this.processLiveMessageInRoomOrder(
+        scope,
+        payload as unknown as VesperMessage
+      )
       return {
         scope,
         event,
@@ -4190,102 +4286,170 @@ export class VesperEncryptedChat {
   }
 
   private async publishScopeRecoveryPackage(scope: EncryptedScope): Promise<void> {
-    const logicalScopeId = this.resolveRoomId(scope)
-    const mlsGroupId = this.resolveMlsGroupId(scope)
-    const ownerId = this.client.getAuthSession()?.user.id ?? this.client.getState().user?.id
-    if (!ownerId || !this.hasGroup(mlsGroupId)) {
+    await this.withStorageContext(async () => {
+      const logicalScopeId = this.resolveRoomId(scope)
+      const mlsGroupId = this.resolveMlsGroupId(scope)
+      const ownerId = this.client.getAuthSession()?.user.id ?? this.client.getState().user?.id
+      if (!ownerId || !this.hasGroup(mlsGroupId)) {
+        return
+      }
+
+      this.recoveryPackageLastRequestedAt.set(logicalScopeId, Date.now())
+      const activePublish = this.recoveryPackagePublishes.get(logicalScopeId)
+      if (activePublish) {
+        this.recoveryPackageRepublishRequested.add(logicalScopeId)
+        return
+      }
+
+      const publish = (async () => {
+        let burstStartedAt = Date.now()
+
+        while (true) {
+          const now = Date.now()
+          const lastRequestedAt =
+            this.recoveryPackageLastRequestedAt.get(logicalScopeId) ?? burstStartedAt
+          const quietAt = lastRequestedAt + SCOPE_RECOVERY_PACKAGE_PUBLISH_QUIET_MS
+          const forcedAt = burstStartedAt + SCOPE_RECOVERY_PACKAGE_PUBLISH_MAX_DELAY_MS
+          const waitMs = Math.max(0, Math.min(quietAt, forcedAt) - now)
+          if (waitMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, waitMs))
+          }
+
+          const afterWait = Date.now()
+          const latestRequestAt =
+            this.recoveryPackageLastRequestedAt.get(logicalScopeId) ?? burstStartedAt
+          if (
+            afterWait < latestRequestAt + SCOPE_RECOVERY_PACKAGE_PUBLISH_QUIET_MS &&
+            afterWait < forcedAt
+          ) {
+            continue
+          }
+
+          // The fresh snapshot includes every request received before this
+          // point. A request arriving while encryption/upload is in flight
+          // starts one trailing burst; continuous traffic is force-flushed at
+          // the maximum delay rather than rewriting a large TOAST value every
+          // debounce interval.
+          this.recoveryPackageRepublishRequested.delete(logicalScopeId)
+          await this.writeScopeRecoveryPackage(logicalScopeId, mlsGroupId, ownerId)
+          if (!this.recoveryPackageRepublishRequested.has(logicalScopeId)) {
+            break
+          }
+          burstStartedAt = Date.now()
+        }
+      })()
+      this.recoveryPackagePublishes.set(logicalScopeId, publish)
+
+      try {
+        await publish
+      } finally {
+        if (this.recoveryPackagePublishes.get(logicalScopeId) === publish) {
+          this.recoveryPackagePublishes.delete(logicalScopeId)
+          this.recoveryPackageLastRequestedAt.delete(logicalScopeId)
+          this.recoveryPackageRepublishRequested.delete(logicalScopeId)
+        }
+      }
+    })
+  }
+
+  private async writeScopeRecoveryPackage(
+    logicalScopeId: string,
+    mlsGroupId: string,
+    ownerId: string
+  ): Promise<void> {
+    const key = await this.recoveryPackageKey(logicalScopeId, ownerId)
+    if (!key) {
       return
     }
 
-    const prior = this.recoveryPackagePublishes.get(logicalScopeId) ?? Promise.resolve()
-    const publish = prior.catch(() => {}).then(async () => {
-      const key = await this.recoveryPackageKey(logicalScopeId, ownerId)
-      if (!key) {
-        return
-      }
+    const [checkpoint, roomKeyCheckpoint, cached] = await Promise.all([
+      this.storage.loadScopeCheckpoint(mlsGroupId),
+      this.storage.loadScopeCheckpoint(logicalScopeId),
+      this.storage.loadCachedMessages(logicalScopeId)
+    ])
+    const messages = cached
+      .map((message) => ({
+        id: message.id,
+        roomSeq: message.roomSeq,
+        channelId: message.channelId,
+        conversationId: message.conversationId,
+        serverId: message.serverId ?? null,
+        senderId: message.senderId,
+        senderUsername: message.senderUsername,
+        parentMessageId: message.parentMessageId,
+        threadRootMessageId: message.threadRootMessageId,
+        replyToMessageId: message.replyToMessageId,
+        isReply: message.isReply,
+        ciphertext: message.ciphertext ? uint8ToBase64(message.ciphertext) : null,
+        plaintext: message.decryptedContent ?? '',
+        mlsEpoch: message.mlsEpoch,
+        insertedAt: message.insertedAt
+      }))
+      .filter((message) => message.plaintext.length > 0)
+      .slice(-MAX_MESSAGES_PER_SCOPE)
 
-      const [checkpoint, roomKeyCheckpoint, cached] = await Promise.all([
-        this.storage.loadScopeCheckpoint(mlsGroupId),
-          this.storage.loadScopeCheckpoint(logicalScopeId),
-        this.storage.loadCachedMessages(logicalScopeId)
-      ])
-      const messages = cached
-        .map((message) => ({
-          id: message.id,
-          roomSeq: message.roomSeq,
-          channelId: message.channelId,
-          conversationId: message.conversationId,
-          serverId: message.serverId ?? null,
-          senderId: message.senderId,
-          senderUsername: message.senderUsername,
-          parentMessageId: message.parentMessageId,
-          threadRootMessageId: message.threadRootMessageId,
-          replyToMessageId: message.replyToMessageId,
-          isReply: message.isReply,
-          ciphertext: message.ciphertext ? uint8ToBase64(message.ciphertext) : null,
-          plaintext: message.decryptedContent ?? '',
-          mlsEpoch: message.mlsEpoch,
-          insertedAt: message.insertedAt
-        }))
-        .filter((message) => message.plaintext.length > 0)
-        .slice(-MAX_MESSAGES_PER_SCOPE)
+    const roomDataKeys = (
+      await Promise.all(
+        roomKeyCheckpoint.roomDataKeys
+          .filter((record) => record.roomId === logicalScopeId)
+          .map(async (record): Promise<ScopeRecoveryPackageRoomDataKey | null> => {
+            try {
+              const plaintext = new Uint8Array(
+                await crypto.subtle.decrypt(
+                  {
+                    name: 'AES-GCM',
+                    iv: record.nonce as unknown as BufferSource,
+                    additionalData: this.roomDataKeyAad(
+                      ownerId,
+                      record.roomId,
+                      record.topologyGeneration,
+                      record.epoch
+                    ) as unknown as BufferSource
+                  },
+                  key,
+                  record.ciphertext as unknown as BufferSource
+                )
+              )
+              if (plaintext.byteLength !== 32) {
+                return null
+              }
 
-        const roomDataKeys = (
-          await Promise.all(
-            roomKeyCheckpoint.roomDataKeys
-              .filter((record) => record.roomId === logicalScopeId)
-              .map(async (record): Promise<ScopeRecoveryPackageRoomDataKey | null> => {
-                try {
-                  const plaintext = new Uint8Array(
-                    await crypto.subtle.decrypt(
-                      {
-                        name: 'AES-GCM',
-                        iv: record.nonce as unknown as BufferSource,
-                        additionalData: this.roomDataKeyAad(ownerId, record.roomId, record.topologyGeneration, record.epoch) as unknown as BufferSource
-                      },
-                      key,
-                      record.ciphertext as unknown as BufferSource
-                    )
-                  )
-                  if (plaintext.byteLength !== 32) {
-                    return null
-                  }
+              return {
+                roomId: record.roomId,
+                topologyGeneration: record.topologyGeneration,
+                epoch: record.epoch,
+                key: uint8ToBase64(plaintext)
+              }
+            } catch {
+              return null
+            }
+          })
+      )
+    ).filter((record): record is ScopeRecoveryPackageRoomDataKey => record != null)
 
-                  return {
-                    roomId: record.roomId,
-                    topologyGeneration: record.topologyGeneration,
-                    epoch: record.epoch,
-                    key: uint8ToBase64(plaintext)
-                  }
-                } catch {
-                  return null
-                }
-              })
-          )
-        ).filter((record): record is ScopeRecoveryPackageRoomDataKey => record != null)
+    if (messages.length === 0 && roomDataKeys.length === 0) {
+      return
+    }
 
-        if (messages.length === 0 && roomDataKeys.length === 0) {
-        return
-      }
+    const payload: ScopeRecoveryPackagePayload = {
+      version: SCOPE_RECOVERY_PACKAGE_VERSION,
+      logicalScopeId,
+      mlsGroupId,
+      ownerId,
+      membershipGeneration: checkpoint.groupState?.epoch ?? 0,
+      lastEventSeq: checkpoint.lastEventSeq,
+      generatedAt: new Date().toISOString(),
+      messages,
+      roomDataKeys
+    }
+    const encoded = new TextEncoder().encode(JSON.stringify(payload))
+    if (encoded.byteLength > MAX_SCOPE_RECOVERY_PACKAGE_BYTES - 28) {
+      return
+    }
 
-      const payload: ScopeRecoveryPackagePayload = {
-        version: SCOPE_RECOVERY_PACKAGE_VERSION,
-        logicalScopeId,
-        mlsGroupId,
-        ownerId,
-        membershipGeneration: checkpoint.groupState?.epoch ?? 0,
-        lastEventSeq: checkpoint.lastEventSeq,
-        generatedAt: new Date().toISOString(),
-        messages,
-          roomDataKeys
-        }
-      const encoded = new TextEncoder().encode(JSON.stringify(payload))
-      if (encoded.byteLength > MAX_SCOPE_RECOVERY_PACKAGE_BYTES - 28) {
-        return
-      }
-
-      const nonce = crypto.getRandomValues(new Uint8Array(12))
-      const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    const nonce = crypto.getRandomValues(new Uint8Array(12))
+    const ciphertext = new Uint8Array(
+      await crypto.subtle.encrypt(
         {
           name: 'AES-GCM',
           iv: nonce,
@@ -4293,12 +4457,15 @@ export class VesperEncryptedChat {
         },
         key,
         encoded
-      ))
-      if (ciphertext.byteLength + nonce.byteLength > MAX_SCOPE_RECOVERY_PACKAGE_BYTES) {
-        return
-      }
+      )
+    )
+    if (ciphertext.byteLength + nonce.byteLength > MAX_SCOPE_RECOVERY_PACKAGE_BYTES) {
+      return
+    }
 
-      await this.client.getHttpClient().apiFetch(`/api/v1/scope-recovery-packages/${logicalScopeId}`, {
+    const response = await this.client
+      .getHttpClient()
+      .apiFetch(`/api/v1/scope-recovery-packages/${logicalScopeId}`, {
         method: 'PUT',
         body: JSON.stringify({
           ciphertext: uint8ToBase64(ciphertext),
@@ -4308,15 +4475,8 @@ export class VesperEncryptedChat {
           schema_version: payload.version
         })
       })
-    })
-    this.recoveryPackagePublishes.set(logicalScopeId, publish)
-
-    try {
-      await publish
-    } finally {
-      if (this.recoveryPackagePublishes.get(logicalScopeId) === publish) {
-        this.recoveryPackagePublishes.delete(logicalScopeId)
-      }
+    if (!response.ok) {
+      throw new Error(`Could not publish scope recovery package: status ${response.status}`)
     }
   }
 

--- a/sdk/test/client-dx.test.mjs
+++ b/sdk/test/client-dx.test.mjs
@@ -1173,6 +1173,89 @@ test('sdk applies live commits through the durable cursor and preserves them acr
   }
 })
 
+test('sdk replays a room gap before applying an out-of-order live MLS message', { concurrency: false }, async (t) => {
+  const stack = await bootServerStack()
+  t.after(async () => {
+    await teardownServerStack(stack)
+  })
+
+  const owner = createClientHarness(stack.apiUrl, 'room-order-owner')
+  const receiver = createClientHarness(stack.apiUrl, 'room-order-receiver')
+  const ownerUsername = uniqueUsername('sdkroomorderowner')
+  const receiverUsername = uniqueUsername('sdkroomorderreceiver')
+  const password = 'vesper-sdk-room-order-password'
+
+  try {
+    await owner.client.register(ownerUsername, password)
+    await receiver.client.register(receiverUsername, password)
+    await owner.client.start(false)
+    await receiver.client.start(false)
+
+    const ownerChat = owner.client.createEncryptedChat()
+    const receiverChat = receiver.client.createEncryptedChat()
+    const server = await owner.client.createServer(`SDK Room Order ${Date.now()}`)
+    const channel = server.channels.find((entry) => entry.name === 'general') ?? null
+    assert.ok(channel, 'expected the default general channel')
+    const invite = await owner.client.createServerInvite(server.id, {})
+    await receiver.client.joinServerByInvite(invite.code)
+    const scope = { kind: 'channel', id: channel.id }
+
+    await ownerChat.watchScope(scope)
+    await receiverChat.watchScope(scope)
+    assert.equal(await ownerChat.createScopeGroup(scope), true)
+    assert.equal(await receiverChat.ensureMembership(scope), true)
+    receiver.client.stop()
+
+    const expected = ['room-order-one', 'room-order-two', 'room-order-three']
+    for (const text of expected) {
+      await ownerChat.sendText(scope, text)
+    }
+
+    const rawMessages = (await receiver.client.fetchChannelMessages(channel.id, { limit: 20 }))
+      .filter((message) => expected.includes(message.content ?? '') || message.ciphertext)
+      .sort((left, right) => (left.room_seq ?? 0) - (right.room_seq ?? 0))
+      .slice(-expected.length)
+    assert.equal(rawMessages.length, expected.length)
+
+    const newestFirst = await receiverChat.processScopeEvent(
+      scope,
+      'new_message',
+      rawMessages.at(-1)
+    )
+    assert.equal(newestFirst?.message?.decryptionFailed, false)
+
+    for (const rawMessage of rawMessages.slice(0, -1).reverse()) {
+      const duplicate = await receiverChat.processScopeEvent(scope, 'new_message', rawMessage)
+      assert.equal(duplicate?.message?.decryptionFailed, false)
+    }
+
+    const restored = receiverChat.getMessages(channel.id)
+    assert.ok(
+      expected.every((text) =>
+        restored.some((message) => message.content === text && !message.decryptionFailed)
+      ),
+      `expected ordered replay to decrypt ${JSON.stringify(expected)}, got ${JSON.stringify(
+        restored.map((message) => ({ content: message.content, failed: message.decryptionFailed }))
+      )}`
+    )
+
+    const newestRoomSeq = rawMessages.at(-1).room_seq
+    assert.equal(typeof newestRoomSeq, 'number')
+    await assert.rejects(
+      receiverChat.processScopeEvent(scope, 'new_message', {
+        ...rawMessages.at(-1),
+        id: crypto.randomUUID(),
+        room_seq: newestRoomSeq + 2
+      }),
+      /Could not replay room .* through sequence/,
+      'a live MLS ciphertext must not consume its ratchet while a prior room sequence is unavailable'
+    )
+  } finally {
+    owner.client.stop()
+    receiver.client.stop()
+  }
+})
+
 test('sdk ignores stale dm join-all replay after restart when the peer is already in the group', { concurrency: false }, async (t) => {
   const stack = await bootServerStack()
   t.after(async () => {
@@ -1796,7 +1879,17 @@ test('sdk restores bounded DM history from an account-owned package after every 
     await teardownServerStack(stack)
   })
 
-  const alicePrimary = createClientHarness(stack.apiUrl, 'package-alice-primary')
+  let recoveryPackagePutCount = 0
+  const countingFetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.url
+    if (init?.method === 'PUT' && url.includes('/api/v1/scope-recovery-packages/')) {
+      recoveryPackagePutCount += 1
+    }
+    return await fetch(input, init)
+  }
+  const alicePrimary = createClientHarness(stack.apiUrl, 'package-alice-primary', {
+    fetchImpl: countingFetch
+  })
   const aliceRecovery = createClientHarness(stack.apiUrl, 'package-alice-recovery')
   const bob = createClientHarness(stack.apiUrl, 'package-bob')
   const aliceUsername = uniqueUsername('sdkpackagealice')
@@ -1854,12 +1947,50 @@ test('sdk restores bounded DM history from an account-owned package after every 
     )
     assert.equal(primaryCachedRecords.length, expected.length)
 
+    let initialRecoveryPackageCiphertext = null
     await waitFor('opaque recovery package persistence', async () => {
       const response = await alicePrimary.client
         .getHttpClient()
         .apiFetch(`/api/v1/scope-recovery-packages/${conversation.channel_id}`)
-      return response.ok
+      if (!response.ok) return false
+      const body = await response.json()
+      initialRecoveryPackageCiphertext = body.package?.ciphertext ?? null
+      return initialRecoveryPackageCiphertext != null
     })
+
+    await waitFor(
+      'recovery package publisher to become idle',
+      async () => aliceChat.recoveryPackagePublishes.size === 0,
+      5_000
+    )
+    assert.ok(recoveryPackagePutCount > 0, 'expected the primary client to publish its initial package')
+    recoveryPackagePutCount = 0
+    const recoveryPublishScope = aliceChat.hasGroup(scope.id)
+      ? scope
+      : { ...scope, id: conversation.channel_id }
+    assert.equal(aliceChat.hasGroup(recoveryPublishScope.id), true)
+    assert.equal(aliceChat.hasGroup(aliceChat.resolveMlsGroupId(recoveryPublishScope)), true)
+    const publishRequests = Array.from(
+      { length: 20 },
+      () => aliceChat.publishScopeRecoveryPackage(recoveryPublishScope)
+    )
+    assert.equal(aliceChat.recoveryPackagePublishes.size, 1)
+    await Promise.all(publishRequests)
+    assert.equal(
+      recoveryPackagePutCount,
+      1,
+      `concurrent recovery-package requests must coalesce into exactly one fresh snapshot upload; got ${recoveryPackagePutCount}`
+    )
+    const refreshedPackageResponse = await alicePrimary.client
+      .getHttpClient()
+      .apiFetch(`/api/v1/scope-recovery-packages/${conversation.channel_id}`)
+    assert.equal(refreshedPackageResponse.ok, true)
+    const refreshedPackage = await refreshedPackageResponse.json()
+    assert.notEqual(
+      refreshedPackage.package?.ciphertext,
+      initialRecoveryPackageCiphertext,
+      'the coalesced publish must replace the durable encrypted package'
+    )
 
     alicePrimary.client.stop()
     bob.client.stop()

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -104,7 +104,9 @@ if config_env() == :prod do
 
   host = System.get_env("PHX_HOST") || "example.com"
 
-  config :vesper, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
+  config :vesper,
+         :dns_cluster_query,
+         Vesper.RuntimeConfig.normalize_dns_cluster_query(System.get_env("DNS_CLUSTER_QUERY"))
 
   run_migrations_on_start =
     case System.get_env("RUN_MIGRATIONS_ON_START", "true") |> String.downcase() do

--- a/server/lib/vesper/encryption.ex
+++ b/server/lib/vesper/encryption.ex
@@ -2079,6 +2079,17 @@ defmodule Vesper.Encryption do
   """
   def upsert_scope_recovery_package(attrs) do
     Repo.transaction(fn ->
+      # FOR UPDATE cannot serialize the initial insert because there is no row
+      # to lock yet. Serialize the owner/scope key itself so two application
+      # nodes cannot both observe nil and race the unique constraint.
+      recovery_package_lock_key =
+        "scope_recovery_package:#{attrs.owner_id}:#{attrs.scope_id}"
+
+      Repo.query!(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        [recovery_package_lock_key]
+      )
+
       existing =
         from(package in ScopeRecoveryPackage,
           where: package.owner_id == ^attrs.owner_id and package.scope_id == ^attrs.scope_id,

--- a/server/lib/vesper/runtime_config.ex
+++ b/server/lib/vesper/runtime_config.ex
@@ -1,6 +1,18 @@
 defmodule Vesper.RuntimeConfig do
   @moduledoc false
 
+  def normalize_dns_cluster_query(nil), do: nil
+
+  def normalize_dns_cluster_query(query) when is_binary(query) do
+    query = String.trim(query)
+
+    cond do
+      query == "" -> nil
+      String.ends_with?(query, ".") -> query
+      true -> query <> "."
+    end
+  end
+
   def secret_or_fallback!(name, configured, fallback, min_bytes)
       when is_binary(name) and is_integer(min_bytes) and min_bytes > 0 do
     candidate =

--- a/server/test/vesper/recovery_package_concurrency_test.exs
+++ b/server/test/vesper/recovery_package_concurrency_test.exs
@@ -7,62 +7,66 @@ defmodule Vesper.RecoveryPackageConcurrencyTest do
   alias Vesper.Repo
 
   test "concurrent first writers use separate database connections and keep the newest cursor" do
-    Sandbox.unboxed_run(Repo, fn ->
-      owner = insert_user()
-      scope_id = Ecto.UUID.generate()
-      parent = self()
-      start_ref = make_ref()
-      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+    owner = Sandbox.unboxed_run(Repo, &insert_user/0)
+    scope_id = Ecto.UUID.generate()
+    parent = self()
+    start_ref = make_ref()
+    expires_at = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
 
-      try do
-        tasks =
-          for cursor <- 1..8 do
-            Task.async(fn ->
-              Sandbox.unboxed_run(Repo, fn ->
-                send(parent, {:recovery_package_writer_ready, self()})
+    try do
+      # Do not hold a parent connection while the six writers wait at the
+      # barrier. The smallest supported CI pool has eight slots, leaving room
+      # for the repository's supervised background processes.
+      tasks =
+        for cursor <- 1..6 do
+          Task.async(fn ->
+            Sandbox.unboxed_run(Repo, fn ->
+              send(parent, {:recovery_package_writer_ready, self()})
 
-                receive do
-                  {:write_recovery_package, ^start_ref} -> :ok
-                end
+              receive do
+                {:write_recovery_package, ^start_ref} -> :ok
+              end
 
-                %{rows: [[backend_pid]]} = Repo.query!("SELECT pg_backend_pid()")
+              %{rows: [[backend_pid]]} = Repo.query!("SELECT pg_backend_pid()")
 
-                result =
-                  Encryption.upsert_scope_recovery_package(%{
-                    owner_id: owner.id,
-                    scope_id: scope_id,
-                    ciphertext: "opaque-#{cursor}",
-                    nonce: :crypto.strong_rand_bytes(12),
-                    membership_generation: 1,
-                    last_event_seq: cursor,
-                    schema_version: 1,
-                    byte_size: 32,
-                    expires_at: expires_at
-                  })
+              result =
+                Encryption.upsert_scope_recovery_package(%{
+                  owner_id: owner.id,
+                  scope_id: scope_id,
+                  ciphertext: "opaque-#{cursor}",
+                  nonce: :crypto.strong_rand_bytes(12),
+                  membership_generation: 1,
+                  last_event_seq: cursor,
+                  schema_version: 1,
+                  byte_size: 32,
+                  expires_at: expires_at
+                })
 
-                {backend_pid, result}
-              end)
+              {backend_pid, result}
             end)
-          end
-
-        for _ <- tasks do
-          assert_receive {:recovery_package_writer_ready, _pid}, 2_000
+          end)
         end
 
-        Enum.each(tasks, fn task ->
-          send(task.pid, {:write_recovery_package, start_ref})
-        end)
+      for _ <- tasks do
+        assert_receive {:recovery_package_writer_ready, _pid}, 5_000
+      end
 
-        results = Enum.map(tasks, &Task.await(&1, 10_000))
-        assert results |> Enum.map(&elem(&1, 0)) |> Enum.uniq() |> length() == 8
-        assert Enum.all?(results, &match?({_backend_pid, {:ok, _}}, &1))
+      Enum.each(tasks, fn task ->
+        send(task.pid, {:write_recovery_package, start_ref})
+      end)
+
+      results = Enum.map(tasks, &Task.await(&1, 10_000))
+      assert results |> Enum.map(&elem(&1, 0)) |> Enum.uniq() |> length() == 6
+      assert Enum.all?(results, &match?({_backend_pid, {:ok, _}}, &1))
+
+      Sandbox.unboxed_run(Repo, fn ->
         assert Repo.aggregate(ScopeRecoveryPackage, :count, :id) == 1
 
-        assert %{last_event_seq: 8, ciphertext: "opaque-8"} =
+        assert %{last_event_seq: 6, ciphertext: "opaque-6"} =
                  Encryption.get_scope_recovery_package(owner.id, scope_id)
-      after
-        Repo.delete!(owner)
-      end
-    end)
+      end)
+    after
+      Sandbox.unboxed_run(Repo, fn -> Repo.delete!(owner) end)
+    end
   end
 end

--- a/server/test/vesper/recovery_package_concurrency_test.exs
+++ b/server/test/vesper/recovery_package_concurrency_test.exs
@@ -1,0 +1,68 @@
+defmodule Vesper.RecoveryPackageConcurrencyTest do
+  use Vesper.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Vesper.Encryption
+  alias Vesper.Encryption.ScopeRecoveryPackage
+  alias Vesper.Repo
+
+  test "concurrent first writers use separate database connections and keep the newest cursor" do
+    Sandbox.unboxed_run(Repo, fn ->
+      owner = insert_user()
+      scope_id = Ecto.UUID.generate()
+      parent = self()
+      start_ref = make_ref()
+      expires_at = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+
+      try do
+        tasks =
+          for cursor <- 1..8 do
+            Task.async(fn ->
+              Sandbox.unboxed_run(Repo, fn ->
+                send(parent, {:recovery_package_writer_ready, self()})
+
+                receive do
+                  {:write_recovery_package, ^start_ref} -> :ok
+                end
+
+                %{rows: [[backend_pid]]} = Repo.query!("SELECT pg_backend_pid()")
+
+                result =
+                  Encryption.upsert_scope_recovery_package(%{
+                    owner_id: owner.id,
+                    scope_id: scope_id,
+                    ciphertext: "opaque-#{cursor}",
+                    nonce: :crypto.strong_rand_bytes(12),
+                    membership_generation: 1,
+                    last_event_seq: cursor,
+                    schema_version: 1,
+                    byte_size: 32,
+                    expires_at: expires_at
+                  })
+
+                {backend_pid, result}
+              end)
+            end)
+          end
+
+        for _ <- tasks do
+          assert_receive {:recovery_package_writer_ready, _pid}, 2_000
+        end
+
+        Enum.each(tasks, fn task ->
+          send(task.pid, {:write_recovery_package, start_ref})
+        end)
+
+        results = Enum.map(tasks, &Task.await(&1, 10_000))
+        assert results |> Enum.map(&elem(&1, 0)) |> Enum.uniq() |> length() == 8
+        assert Enum.all?(results, &match?({_backend_pid, {:ok, _}}, &1))
+        assert Repo.aggregate(ScopeRecoveryPackage, :count, :id) == 1
+
+        assert %{last_event_seq: 8, ciphertext: "opaque-8"} =
+                 Encryption.get_scope_recovery_package(owner.id, scope_id)
+      after
+        Repo.delete!(owner)
+      end
+    end)
+  end
+end

--- a/server/test/vesper/runtime_config_test.exs
+++ b/server/test/vesper/runtime_config_test.exs
@@ -5,6 +5,16 @@ defmodule Vesper.RuntimeConfigTest do
 
   @fallback String.duplicate("fallback-secret-", 3)
 
+  test "DNS cluster queries are normalized to absolute A/AAAA names" do
+    assert RuntimeConfig.normalize_dns_cluster_query(nil) == nil
+    assert RuntimeConfig.normalize_dns_cluster_query("") == nil
+    assert RuntimeConfig.normalize_dns_cluster_query("   ") == nil
+    assert RuntimeConfig.normalize_dns_cluster_query("vesper-apps") == "vesper-apps."
+
+    assert RuntimeConfig.normalize_dns_cluster_query(" vesper-apps.internal. ") ==
+             "vesper-apps.internal."
+  end
+
   test "blank optional secrets use the strong fallback" do
     assert RuntimeConfig.secret_or_fallback!("JWT_SECRET", nil, @fallback, 32) == @fallback
     assert RuntimeConfig.secret_or_fallback!("JWT_SECRET", "", @fallback, 32) == @fallback

--- a/server/test/vesper/turn_config_test.exs
+++ b/server/test/vesper/turn_config_test.exs
@@ -1,0 +1,81 @@
+defmodule Vesper.TurnConfigTest do
+  use ExUnit.Case, async: true
+
+  @required_denials ~w(
+    0.0.0.0-0.255.255.255
+    10.0.0.0-10.255.255.255
+    100.64.0.0-100.127.255.255
+    127.0.0.0-127.255.255.255
+    169.254.0.0-169.254.255.255
+    172.16.0.0-172.31.255.255
+    192.0.0.0-192.0.0.255
+    192.0.2.0-192.0.2.255
+    192.88.99.0-192.88.99.255
+    192.168.0.0-192.168.255.255
+    198.18.0.0-198.19.255.255
+    198.51.100.0-198.51.100.255
+    203.0.113.0-203.0.113.255
+    224.0.0.0-255.255.255.255
+    ::1
+    ::ffff:0:0-::ffff:ffff:ffff
+    64:ff9b::-64:ff9b::ffff:ffff
+    64:ff9b:1::-64:ff9b:1:ffff:ffff:ffff:ffff:ffff
+    100::-100::ffff:ffff:ffff:ffff
+    100:0:0:1::-100:0:0:1:ffff:ffff:ffff:ffff
+    2001::-2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff
+    2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff
+    2002::-2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    3fff::-3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff
+    5f00::-5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    fec0::-feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+    ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  )
+
+  @required_allowances ~w(
+    2001:1::1
+    2001:1::2
+    2001:1::3
+    2001:3::-2001:3:ffff:ffff:ffff:ffff:ffff:ffff
+    2001:4:112::-2001:4:112:ffff:ffff:ffff:ffff:ffff
+    2001:20::-2001:2f:ffff:ffff:ffff:ffff:ffff:ffff
+    2001:30::-2001:3f:ffff:ffff:ffff:ffff:ffff:ffff
+  )
+
+  test "bundled TURN policy denies private and special-use peer destinations" do
+    config =
+      __DIR__
+      |> Path.join("../../../turnserver.conf")
+      |> Path.expand()
+      |> File.read!()
+
+    lines = String.split(config, "\n")
+
+    denials =
+      lines
+      |> Enum.filter(&String.starts_with?(&1, "denied-peer-ip="))
+      |> Enum.map(&String.replace_prefix(&1, "denied-peer-ip=", ""))
+
+    allowances =
+      lines
+      |> Enum.filter(&String.starts_with?(&1, "allowed-peer-ip="))
+      |> Enum.map(&String.replace_prefix(&1, "allowed-peer-ip=", ""))
+
+    assert length(denials) == MapSet.size(MapSet.new(denials)),
+           "TURN peer-denial ranges must not be duplicated"
+
+    assert length(allowances) == MapSet.size(MapSet.new(allowances)),
+           "TURN peer-allowance ranges must not be duplicated"
+
+    assert MapSet.subset?(MapSet.new(@required_denials), MapSet.new(denials))
+    assert MapSet.new(allowances) == MapSet.new(@required_allowances)
+    assert "no-multicast-peers" in lines
+    assert "no-tls" in lines
+    assert "no-dtls" in lines
+    refute "cli" in lines
+    refute "no-cli" in lines
+    refute String.contains?(config, "allow-loopback-peers\n")
+    refute "no-loopback-peers" in lines
+  end
+end

--- a/turnserver.conf
+++ b/turnserver.conf
@@ -1,7 +1,10 @@
 # coturn TURN server configuration
 
 listening-port=3478
-tls-listening-port=5349
+# The bundled deployment advertises turn:, not turns:. TLS/DTLS requires a
+# separately configured certificate and listener.
+no-tls
+no-dtls
 
 # Relay ports for WebRTC media
 min-port=50000
@@ -14,7 +17,8 @@ max-port=50100
 # Never relay traffic into host/LAN/link-local/multicast/reserved networks.
 # TURN is an Internet media relay, not an authenticated proxy into the
 # deployment's private network.
-no-loopback-peers
+# Loopback peers are denied by coturn by default. Do not set
+# allow-loopback-peers; there is no inverse no-loopback-peers option.
 no-multicast-peers
 denied-peer-ip=0.0.0.0-0.255.255.255
 denied-peer-ip=10.0.0.0-10.255.255.255
@@ -23,12 +27,43 @@ denied-peer-ip=127.0.0.0-127.255.255.255
 denied-peer-ip=169.254.0.0-169.254.255.255
 denied-peer-ip=172.16.0.0-172.31.255.255
 denied-peer-ip=192.0.0.0-192.0.0.255
+denied-peer-ip=192.0.2.0-192.0.2.255
+denied-peer-ip=192.88.99.0-192.88.99.255
 denied-peer-ip=192.168.0.0-192.168.255.255
 denied-peer-ip=198.18.0.0-198.19.255.255
+denied-peer-ip=198.51.100.0-198.51.100.255
+denied-peer-ip=203.0.113.0-203.0.113.255
 denied-peer-ip=224.0.0.0-255.255.255.255
+
+# IPv6 special-use and transition prefixes. Deny transition mechanisms that
+# can encode an IPv4 destination so an IPv6 peer address cannot bypass the
+# IPv4 private/special-use policy through mapped, NAT64, Teredo, or 6to4 forms.
 denied-peer-ip=::1
+denied-peer-ip=::ffff:0:0-::ffff:ffff:ffff
+denied-peer-ip=64:ff9b::-64:ff9b::ffff:ffff
+denied-peer-ip=64:ff9b:1::-64:ff9b:1:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=100::-100::ffff:ffff:ffff:ffff
+denied-peer-ip=100:0:0:1::-100:0:0:1:ffff:ffff:ffff:ffff
+
+# The IETF assignments block defaults non-global. Coturn evaluates its static
+# allow list before its static deny list, so preserve only the IANA allocations
+# within this block that are explicitly globally reachable.
+denied-peer-ip=2001::-2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff
+allowed-peer-ip=2001:1::1
+allowed-peer-ip=2001:1::2
+allowed-peer-ip=2001:1::3
+allowed-peer-ip=2001:3::-2001:3:ffff:ffff:ffff:ffff:ffff:ffff
+allowed-peer-ip=2001:4:112::-2001:4:112:ffff:ffff:ffff:ffff:ffff
+allowed-peer-ip=2001:20::-2001:2f:ffff:ffff:ffff:ffff:ffff:ffff
+allowed-peer-ip=2001:30::-2001:3f:ffff:ffff:ffff:ffff:ffff:ffff
+
+denied-peer-ip=2001:db8::-2001:db8:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=2002::-2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=3fff::-3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=5f00::-5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=fec0::-feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 denied-peer-ip=ff00::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 
 # Bound a leaked shared beta credential. These quotas apply to the bundled
@@ -41,8 +76,7 @@ max-bps=5000000
 log-file=stdout
 verbose
 
-# Disable CLI
-no-cli
+# The administrative CLI is disabled by default; do not enable `cli`.
 
 # Fingerprint for TURN messages
 fingerprint


### PR DESCRIPTION
## Why

The merged `0c2ec94` candidate passed the pre-merge suite but failed the first two-node release canary in three release-blocking ways:

- concurrent first recovery-package writes raced the unique index because `FOR UPDATE` cannot lock a row that does not exist;
- Phoenix broadcasts emitted by different application nodes could arrive out of durable `room_seq` order and consume one-shot MLS ratchets out of order; and
- whole-window recovery-package publishing rewrote large PostgreSQL TOAST values continuously under message load.

The same canary also exposed incomplete TURN peer filtering and incorrect DNS clustering guidance (`DNSCluster` performs A/AAAA lookups, not SRV; Docker resolution required an absolute query).

## What changed

### Recovery packages and MLS ordering

- Serialize `(owner_id, scope_id)` recovery-package creation/update with a transaction-scoped PostgreSQL advisory lock before the row lock.
- Exercise six genuinely concurrent first writers on six distinct PostgreSQL backend connections; the newest cursor wins and only one row survives.
- Treat a live `new_message` event with a `room_seq` gap as a wake-up signal. Replay committed sorted message/mutation pages before processing the live ciphertext, and fail closed if durable replay cannot establish the immediately preceding sequence.
- Run recovery publishing in the client's storage context, propagate non-2xx PUT failures, and prove a concurrent burst performs exactly one real durable replacement.
- Replace one-second whole-window rewrites with a two-second quiet window plus a 30-second maximum flush interval. Requests during encryption/upload schedule one trailing burst.

### TURN and clustering

- Cover all current IANA non-global IPv4/IPv6 special-use space, plus mapped/NAT64/Teredo/6to4 forms that can encode or tunnel an IPv4 destination.
- Deny the default-non-global `2001::/23` block and narrowly allow only its current globally reachable IANA allocations. The pinned coturn implementation evaluates static allowances before static denials.
- Remove unsupported/deprecated coturn options and explicitly disable TLS/DTLS in the bundled non-`turns:` deployment.
- Add an executable pinned-image policy test: config parsing, public IPv4 relay, IPv6 allow-over-deny precedence, and explicit 403 denial for private IPv4, documentation space, ULA, NAT64-private, and IPv4-mapped-private peers.
- Normalize `DNS_CLUSTER_QUERY` to an absolute A/AAAA name and correct the SRV documentation.
- Add a Docker test that migrates a clean database, starts two long-name release nodes, and proves bidirectional discovery through the normalized query.
- Wire both gates into the required Docker workflow and fail the aggregate gate if change detection itself fails.

## Evidence

Local committed-tree validation:

- Server compile + full suite: **179 passed**.
- SDK typecheck + full integration suite with the CI performance multiplier: **69 passed**.
- Client unit/typecheck/build: **60 passed** and production build completed.
- TURN policy script passed against the exact Compose pin `coturn/coturn@sha256:01fc8655e7c262fa4ccfb8dca74ff80fb372b0ee021e80370a4d3e3dd01a951e`.
- DNS Docker script: `vesper-apps` normalized to `vesper-apps.`; both application nodes discovered each other.
- 30-second write-heavy recovery load: **1,021 operations**, 0 correctness/decrypt/restore failures. Recovery-package relation changed from **48,185,344** to **48,201,728 bytes** (+16 KiB) while logical package bytes grew by ~890 KiB; only four inserts and two updates occurred.
- Two-node four-worker canary: **36 actors, 7,151 operations**, 0 failures, 0 decrypt failures, 0 restore misses; `CHAOS_MULTI_COHORT_SIZE=0`; recovery-package relation and write counters remained unchanged.

## Scope and remaining gates

This does **not** tag or release `v0.2.0`, deploy Vesper, enable production multi-cohort mutation, or claim production/multi-region evidence. After merge, release evidence still has to be repeated from immutable images built from the new merged SHA. External relay-only TURN validation and native Apple/Windows signing credentials also remain separate release prerequisites.
