### PR TITLE
Add explicit unsigned public-beta release path

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -55,22 +55,27 @@ A push to `main` builds native `linux/amd64` and `linux/arm64` images and publis
 
 These workflows emit SBOMs and build provenance, but they do not publish versioned production tags. Operators must not deploy mutable `main` tags as releases.
 
-### `release.yml` — stable release gate
+### `release.yml` — exact-source validation and release gate
 
-This workflow is manually dispatched from an existing `v<version>` tag, with the same tag supplied as its input. It fails unless the selected ref, checked-out commit, GitHub workflow identity, and `client/package.json` version agree.
+This workflow has two deliberately separate modes. A validation-only dispatch from `main` (`publish=false`) runs the complete protocol, browser/Electron, desktop-platform, and container matrix without creating a tag or release. Publication (`publish=true`) must be dispatched from an existing immutable `v<version>` tag with the same tag supplied as input. Both modes fail unless the checked-out commit, GitHub workflow identity, requested release identity, and `client/package.json` version agree.
+
+The caller also selects an explicit native trust policy:
+
+- `signed` requires and verifies Apple Developer ID/notarization plus Windows Authenticode credentials;
+- `unsigned-beta` disables certificate discovery, marks the GitHub release as a prerelease, and adds an attested `UNSIGNED-NATIVE-BUILDS.txt` disclosure. Checksums and GitHub provenance still bind the produced bytes, but do not claim native platform trust.
 
 The release gate performs, in order:
 
 1. server and SDK audits, warnings-as-errors compilation, migration verification, server tests, and live SDK protocol tests;
-2. the retained browser/Electron invariant suite against the exact tag, with failure evidence retained for 14 days;
-3. native desktop builds for Linux, macOS x64/arm64, and Windows;
-4. mandatory macOS signing/notarization and Windows Authenticode verification;
+2. the retained browser/Electron invariant suite against the selected exact source, with failure evidence retained for 14 days;
+3. native desktop builds for Linux, macOS x64/arm64, and Windows under the selected trust policy;
+4. mandatory native signature/notarization verification in `signed` mode, or explicit untrusted-beta disclosure in `unsigned-beta` mode;
 5. native amd64/arm64 candidate builds for both container images, each with SBOM and provenance;
-6. release-set validation, checksums, GitHub build-provenance attestation, and a complete draft GitHub release;
+6. on a publication run only, release-set validation, checksums, GitHub build-provenance attestation, and a complete draft GitHub release;
 7. publication of versioned multi-architecture container manifests;
-8. conversion of the verified draft into a public release.
+8. conversion of the verified draft into a public release or prerelease.
 
-If required signing credentials or any platform artifact are absent, no public GitHub release is created. GitHub Releases and GHCR are separate publication systems and cannot commit atomically: all candidates and the draft are validated first, but a failure while creating the two final OCI manifests can leave one version tag visible while the GitHub release remains draft. Treat that as a failed release, remove the partial OCI tag, and rerun only after reconciling both registries. Follow `docs/RELEASE-RUNBOOK.md` for credentials, canarying, migration, verification, and rollback.
+A missing platform artifact always blocks publication; missing signing credentials block only the `signed` policy. GitHub Releases and GHCR are separate publication systems and cannot commit atomically: all candidates and the draft are validated first, but a failure while creating the two final OCI manifests can leave one version tag visible while the GitHub release remains draft. Treat that as a failed release, remove the partial OCI tag, and rerun only after reconciling both registries. Follow `docs/RELEASE-RUNBOOK.md` for trust policy, canarying, migration, verification, and rollback.
 
 ### `nightly.yml` — distributed recovery validation only
 
@@ -90,4 +95,4 @@ The multiplier absorbs runner variance; it is not permission to ignore order-of-
 - CI service images and Docker base images are pinned by digest.
 - Stable desktop and versioned OCI artifacts come only from `release.yml`.
 - Production Compose deployments require explicit release images through `VESPER_APP_IMAGE` and `VESPER_WEB_IMAGE`; mutable `main`, `latest`, and former nightly tags are not release inputs.
-- The Electron updater follows stable signed releases (`allowPrerelease=false`).
+- The Electron updater follows stable releases (`allowPrerelease=false`); an unsigned beta is deliberately marked prerelease and is never offered as an automatic stable update.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing release tag to build (for example v0.2.0)'
+        description: 'Release identity to validate or publish (for example v0.2.0)'
         required: true
+      publish:
+        description: 'Publish the existing immutable tag; false validates current main without creating a release'
+        required: true
+        type: boolean
+        default: false
+      signing_mode:
+        description: 'Native desktop trust policy'
+        required: true
+        type: choice
+        default: unsigned-beta
+        options:
+          - unsigned-beta
+          - signed
 
 permissions:
   contents: read
@@ -42,18 +55,23 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.publish && inputs.tag || github.sha }}
           fetch-depth: 0
 
       - name: Verify protocol-gate source identity
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
           expected="v$(node -p "require('./client/package.json').version")"
           test "$RELEASE_TAG" = "$expected"
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          if [ "$PUBLISH" = true ]; then
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+          else
+            test "$GITHUB_REF" = "refs/heads/main"
+          fi
 
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         with:
@@ -108,18 +126,23 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.publish && inputs.tag || github.sha }}
           fetch-depth: 0
 
       - name: Verify browser-gate source identity
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
           expected="v$(node -p "require('./client/package.json').version")"
           test "$RELEASE_TAG" = "$expected"
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          if [ "$PUBLISH" = true ]; then
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+          else
+            test "$GITHUB_REF" = "refs/heads/main"
+          fi
 
       - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
         with:
@@ -203,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.publish && inputs.tag || github.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -212,24 +235,32 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
 
-      - name: Verify tag matches the packaged version
+      - name: Verify release source identity
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
           expected="v$(node -p "require('./client/package.json').version")"
           test "$RELEASE_TAG" = "$expected" || {
-            echo "Release tag $RELEASE_TAG does not match client version $expected" >&2
-            exit 1
-          }
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG" || {
-            echo "Dispatch this workflow from the $RELEASE_TAG tag ref so provenance matches the built commit" >&2
+            echo "Release identity $RELEASE_TAG does not match client version $expected" >&2
             exit 1
           }
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          if [ "$PUBLISH" = true ]; then
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG" || {
+              echo "Publication must be dispatched from refs/tags/$RELEASE_TAG" >&2
+              exit 1
+            }
+          else
+            test "$GITHUB_REF" = "refs/heads/main" || {
+              echo "Validation-only runs must be dispatched from main" >&2
+              exit 1
+            }
+          fi
 
       - name: Require native signing credentials
-        if: matrix.platform != 'linux'
+        if: matrix.platform != 'linux' && inputs.signing_mode == 'signed'
         shell: bash
         env:
           CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_LINK || secrets.WINDOWS_CSC_LINK }}
@@ -267,9 +298,10 @@ jobs:
         working-directory: client
         run: npm run build
 
-      - name: Package signed artifacts
+      - name: Package native artifacts
         working-directory: client
         env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ inputs.signing_mode == 'signed' && 'true' || 'false' }}
           CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_LINK || secrets.WINDOWS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_KEY_PASSWORD || secrets.WINDOWS_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -277,8 +309,8 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npx electron-builder ${{ matrix.args }} --publish never
 
-      - name: Verify macOS application signature
-        if: matrix.platform == 'mac'
+      - name: Verify macOS application signature and notarization
+        if: matrix.platform == 'mac' && inputs.signing_mode == 'signed'
         shell: bash
         run: |
           app_count=0
@@ -290,7 +322,7 @@ jobs:
           test "$app_count" -ge 2
 
       - name: Verify Windows executable signatures
-        if: matrix.platform == 'win'
+        if: matrix.platform == 'win' && inputs.signing_mode == 'signed'
         shell: pwsh
         run: |
           $executables = Get-ChildItem client/dist -Filter *.exe
@@ -312,7 +344,7 @@ jobs:
             -exec cp {} "release-${{ matrix.platform }}/" \;
           test "$(find "release-${{ matrix.platform }}" -type f | wc -l)" -gt 0
 
-      - name: Upload verified build artifacts
+      - name: Upload gated build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: vesper-${{ matrix.platform }}
@@ -354,16 +386,23 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.publish && inputs.tag || github.sha }}
           fetch-depth: 0
 
       - name: Verify container source identity
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+          expected="v$(node -p "require('./client/package.json').version")"
+          test "$RELEASE_TAG" = "$expected"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          if [ "$PUBLISH" = true ]; then
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
+          else
+            test "$GITHUB_REF" = "refs/heads/main"
+          fi
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -391,6 +430,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=release-${{ matrix.image }}-${{ matrix.arch }}
 
   publish:
+    if: inputs.publish
     needs: [build, container-build]
     runs-on: ubuntu-latest
     permissions:
@@ -427,6 +467,24 @@ jobs:
           path: release-assets
           merge-multiple: true
 
+      - name: Add unsigned beta disclosure
+        if: inputs.signing_mode == 'unsigned-beta'
+        shell: bash
+        run: |
+          cat > release-assets/UNSIGNED-NATIVE-BUILDS.txt <<'EOF'
+          Vesper unsigned native beta
+          ===========================
+
+          The macOS and Windows artifacts in this beta are intentionally not
+          signed with Apple Developer ID or Windows Authenticode certificates,
+          and the macOS applications are not notarized. Operating-system trust
+          warnings are expected.
+
+          SHA256SUMS and GitHub build-provenance attestations establish the
+          exact bytes produced by Vesper's release workflow; they do not replace
+          native platform trust or remove Gatekeeper/SmartScreen warnings.
+          EOF
+
       - name: Verify release set and generate checksums
         shell: bash
         run: |
@@ -462,6 +520,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag }}
+          SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             is_draft="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq .draft)"
@@ -472,11 +531,22 @@ jobs:
             gh release delete "$RELEASE_TAG" --yes
           fi
 
-          gh release create "$RELEASE_TAG" release-assets/* \
-            --verify-tag \
-            --draft \
-            --generate-notes \
-            --title "Vesper $RELEASE_TAG"
+          title="Vesper $RELEASE_TAG"
+          release_flags=(--verify-tag --draft --generate-notes --title "$title")
+          if [ "$SIGNING_MODE" = unsigned-beta ]; then
+            release_flags+=(--prerelease)
+          fi
+          gh release create "$RELEASE_TAG" release-assets/* "${release_flags[@]}"
+
+          if [ "$SIGNING_MODE" = unsigned-beta ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq .body > /tmp/generated-notes.md
+            {
+              printf '%s\n\n' '> [!WARNING]'
+              printf '%s\n\n' '> This public beta contains unsigned Windows and unnotarized macOS builds. See `UNSIGNED-NATIVE-BUILDS.txt` before installing.'
+              cat /tmp/generated-notes.md
+            } > /tmp/release-notes.md
+            gh release edit "$RELEASE_TAG" --notes-file /tmp/release-notes.md
+          fi
 
           local_count="$(find release-assets -maxdepth 1 -type f | wc -l)"
           remote_count="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.assets | length')"

--- a/.github/workflows/validate-public-deployment.yml
+++ b/.github/workflows/validate-public-deployment.yml
@@ -1,0 +1,73 @@
+name: Validate Public Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      public_url:
+        description: 'Public HTTPS origin to validate'
+        required: true
+      turn_server_url:
+        description: 'Public TURN URL without embedded credentials'
+        required: true
+        default: 'turn:127.0.0.1:3478'
+
+permissions:
+  contents: read
+
+jobs:
+  external-boundaries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PUBLIC_URL: ${{ inputs.public_url }}
+      TURN_SERVER_URL: ${{ inputs.turn_server_url }}
+      TURN_USERNAME: ${{ secrets.BETA_TURN_USERNAME }}
+      TURN_PASSWORD: ${{ secrets.BETA_TURN_PASSWORD }}
+      TURN_EVIDENCE_PATH: external-turn-evidence.json
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Require controlled external-test credentials
+        shell: bash
+        run: |
+          test -n "$TURN_USERNAME"
+          test -n "$TURN_PASSWORD"
+          case "$PUBLIC_URL" in https://*) ;; *) echo 'public_url must use HTTPS' >&2; exit 1 ;; esac
+          case "$TURN_SERVER_URL" in turn:*|turns:*) ;; *) echo 'turn_server_url must use turn: or turns:' >&2; exit 1 ;; esac
+
+      - name: Validate public web, API, and WebSocket edge
+        shell: bash
+        run: |
+          curl --fail --show-error --silent --retry 5 --retry-all-errors \
+            --connect-timeout 10 --max-time 30 "$PUBLIC_URL/health" \
+            | tee public-health.json
+          jq -e '.status == "ok" and .database == "ok" and .migrations == "ok"' public-health.json
+          curl --fail --show-error --silent --retry 5 --retry-all-errors \
+            --connect-timeout 10 --max-time 30 "$PUBLIC_URL/" >/dev/null
+
+      - name: Install Chromium boundary
+        working-directory: client
+        run: |
+          npm ci --workspaces=false
+          npx playwright install chromium --with-deps
+
+      - name: Prove relay-only UDP and TCP payloads externally
+        run: node client/scripts/test-external-turn.mjs
+
+      - name: Upload sanitized deployment evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: public-deployment-evidence
+          path: |
+            public-health.json
+            external-turn-evidence.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ scripts/                 repo-level tooling
   test-client.yml          client CI — typecheck + production build
   docker-server.yml        build & push attested main/SHA server snapshots
   docker-web.yml           build & push attested main/SHA web snapshots
-  release.yml              signed desktop + attested container release gate
+  release.yml              explicit signed/unsigned-beta desktop + attested container gate
   nightly.yml              CI-only distributed recovery soak
 .github/CI.md             CI/CD pipeline documentation
 
@@ -316,7 +316,7 @@ To change the limit, update **both** values. They must match — if `Plug.Parser
 
 ## Security and release operations
 
-Report vulnerabilities through [SECURITY.md](SECURITY.md). Operators and release maintainers should follow the [public-beta release runbook](docs/RELEASE-RUNBOOK.md) for signing, migration rehearsal, canarying, monitoring, and rollback.
+Report vulnerabilities through [SECURITY.md](SECURITY.md). Operators and release maintainers should follow the [public-beta release runbook](docs/RELEASE-RUNBOOK.md) for native trust disclosure, migration rehearsal, canarying, monitoring, and rollback.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Do not open a public issue for a vulnerability that could expose message content
 
 ## Supported versions
 
-Only the newest published release receives security fixes. Release artifacts are accepted only from the repository's release workflow; verify `SHA256SUMS`, GitHub build provenance, and native platform signatures on macOS/Windows before installation. Linux packages rely on the checksums and GitHub provenance rather than a separate native signature.
+Only the newest published release receives security fixes. Release artifacts are accepted only from the repository's release workflow. Always verify `SHA256SUMS` and GitHub build provenance. A release marked `unsigned-beta` intentionally lacks Apple Developer ID/notarization and Windows Authenticode trust; verify its attested `UNSIGNED-NATIVE-BUILDS.txt` disclosure and expect operating-system warnings. For a release using the `signed` policy, additionally verify native platform signatures. Linux packages rely on checksums and GitHub provenance rather than a separate native signature in either mode.
 
 ## Deployment defaults
 

--- a/client/scripts/test-external-turn.mjs
+++ b/client/scripts/test-external-turn.mjs
@@ -1,0 +1,139 @@
+import { chromium } from 'playwright'
+
+const required = (name) => {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+const baseUrl = required('TURN_SERVER_URL').replace(/\?.*$/, '')
+const username = required('TURN_USERNAME')
+const credential = required('TURN_PASSWORD')
+const outputPath = process.env.TURN_EVIDENCE_PATH?.trim() || 'external-turn-evidence.json'
+
+const transports = ['udp', 'tcp']
+const evidence = {
+  started_at: new Date().toISOString(),
+  turn_server: baseUrl.replace(/^(turns?:)[^@]*@/, '$1[redacted]@'),
+  checks: {}
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  for (const transport of transports) {
+    const result = await page.evaluate(
+      async ({ url, username, credential, transport }) => {
+        const timeout = (promise, milliseconds, label) =>
+          Promise.race([
+            promise,
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error(`${label} timed out after ${milliseconds} ms`)), milliseconds)
+            )
+          ])
+
+        const waitForIceComplete = (pc) => {
+          if (pc.iceGatheringState === 'complete') return Promise.resolve()
+          return new Promise((resolve) => {
+            const listener = () => {
+              if (pc.iceGatheringState === 'complete') {
+                pc.removeEventListener('icegatheringstatechange', listener)
+                resolve()
+              }
+            }
+            pc.addEventListener('icegatheringstatechange', listener)
+          })
+        }
+
+        const pc1 = new RTCPeerConnection({
+          iceServers: [{ urls: `${url}?transport=${transport}`, username, credential }],
+          iceTransportPolicy: 'relay'
+        })
+        const pc2 = new RTCPeerConnection({
+          iceServers: [{ urls: `${url}?transport=${transport}`, username, credential }],
+          iceTransportPolicy: 'relay'
+        })
+
+        try {
+          const receivedByPeer = new Promise((resolve) => {
+            pc2.addEventListener('datachannel', (event) => {
+              event.channel.addEventListener('message', (message) => {
+                event.channel.send(`echo:${message.data}`)
+                resolve(message.data)
+              })
+            })
+          })
+          const channel = pc1.createDataChannel(`vesper-turn-${transport}`)
+          const opened = new Promise((resolve) => channel.addEventListener('open', resolve, { once: true }))
+          const echoed = new Promise((resolve) =>
+            channel.addEventListener('message', (event) => resolve(event.data), { once: true })
+          )
+
+          await pc1.setLocalDescription(await pc1.createOffer())
+          await timeout(waitForIceComplete(pc1), 20_000, `${transport} offer ICE gathering`)
+          await pc2.setRemoteDescription(pc1.localDescription)
+          await pc2.setLocalDescription(await pc2.createAnswer())
+          await timeout(waitForIceComplete(pc2), 20_000, `${transport} answer ICE gathering`)
+          await pc1.setRemoteDescription(pc2.localDescription)
+          await timeout(opened, 25_000, `${transport} relay data channel`)
+
+          const offerCandidates = pc1.localDescription.sdp
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('a=candidate:'))
+          const answerCandidates = pc2.localDescription.sdp
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('a=candidate:'))
+          const candidates = [...offerCandidates, ...answerCandidates]
+          if (candidates.length === 0 || candidates.some((line) => !line.includes(' typ relay '))) {
+            throw new Error(`Expected relay-only ICE candidates for ${transport}`)
+          }
+
+          const nonce = `vesper-external-turn-${transport}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+          channel.send(nonce)
+          const [peerMessage, echoMessage] = await timeout(
+            Promise.all([receivedByPeer, echoed]),
+            10_000,
+            `${transport} relayed payload`
+          )
+          if (peerMessage !== nonce || echoMessage !== `echo:${nonce}`) {
+            throw new Error(`Relayed ${transport} payload mismatch`)
+          }
+
+          const candidateSummary = candidates.map((line) => {
+            const fields = line.slice('a=candidate:'.length).trim().split(/\s+/)
+            return {
+              protocol: fields[2]?.toLowerCase(),
+              address_family: fields[4]?.includes(':') ? 'ipv6' : 'ipv4',
+              type: fields[fields.indexOf('typ') + 1]
+            }
+          })
+
+          return {
+            status: 'passed',
+            candidate_count: candidateSummary.length,
+            candidates: candidateSummary,
+            payload_round_trip: 'passed'
+          }
+        } finally {
+          pc1.close()
+          pc2.close()
+        }
+      },
+      { url: baseUrl, username, credential, transport }
+    )
+    evidence.checks[transport] = result
+  }
+  evidence.status = 'passed'
+} catch (error) {
+  evidence.status = 'failed'
+  evidence.error = error instanceof Error ? error.stack : String(error)
+  throw error
+} finally {
+  evidence.completed_at = new Date().toISOString()
+  await import('node:fs/promises').then(({ writeFile }) =>
+    writeFile(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 })
+  )
+  await browser.close()
+}
+
+console.log(JSON.stringify(evidence, null, 2))

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -84,7 +84,7 @@ The bundled server uses coturn long-term credentials because Vesper currently re
 
 `TURN_SERVER_URL` is delivered to remote clients, so `turn:coturn:3478` is invalid. If the relay is behind NAT, set `TURN_EXTERNAL_IP` in coturn's `public-ip/private-ip` form. A `turns:` URL requires certificates and TLS ingress configured separately; setting the URL alone does not enable TLS.
 
-After deployment, prove relay behavior from outside the server's network. Host reachability is not enough: establish a WebRTC call with relay-only ICE policy and verify a `relay` candidate carries media in both directions.
+After deployment, prove relay behavior from outside the server's network. Host reachability is not enough: establish a WebRTC call with relay-only ICE policy and verify a `relay` candidate carries media in both directions. Repository maintainers can temporarily configure the `BETA_TURN_USERNAME`/`BETA_TURN_PASSWORD` Actions secrets and dispatch `validate-public-deployment.yml`; its GitHub-hosted Chromium proves relay-only UDP and TCP payload round trips and uploads sanitized evidence. Remove those temporary secrets after validation.
 
 ## Initial deployment
 

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -4,12 +4,10 @@ A Vesper release is not ready because it compiles. The operator must be able to 
 
 ## Required release inputs
 
-- A tag exactly matching `client/package.json` (`v<version>`).
-- macOS Developer ID certificate and notarization credentials:
-  `MACOS_CSC_LINK`, `MACOS_CSC_KEY_PASSWORD`, `APPLE_ID`,
-  `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`.
-- Windows Authenticode certificate:
-  `WINDOWS_CSC_LINK` and `WINDOWS_CSC_KEY_PASSWORD`.
+- A release identity exactly matching `client/package.json` (`v<version>`). Run the full workflow once from current `main` with `publish=false` before creating that immutable tag; publication then requires the tag ref and `publish=true`.
+- An explicit native trust policy:
+  - `signed`: macOS Developer ID certificate and notarization credentials (`MACOS_CSC_LINK`, `MACOS_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`) plus a Windows Authenticode certificate (`WINDOWS_CSC_LINK` and `WINDOWS_CSC_KEY_PASSWORD`);
+  - `unsigned-beta`: no native signing credentials, but the release is forced to GitHub prerelease status and includes `UNSIGNED-NATIVE-BUILDS.txt`. Gatekeeper and SmartScreen warnings are expected and must not be described as signed or trusted builds.
 - Production runtime secrets of at least 32 random bytes where required:
   `SECRET_KEY_BASE`, `METRICS_TOKEN`, `TURN_PASSWORD`, and, when used,
   `REGISTRATION_INVITE_SECRET`.
@@ -19,7 +17,9 @@ A Vesper release is not ready because it compiles. The operator must be able to 
 - A tested PostgreSQL backup and a restore target separate from production.
 - `VESPER_APP_IMAGE` and `VESPER_WEB_IMAGE` pinned to the same release version or immutable OCI digests. Production must not use `main`, `latest`, or a nightly artifact.
 
-The release workflow fails closed if native signing/notarization credentials are absent. It publishes only after all three desktop platforms and both architectures of both container images pass, creates `SHA256SUMS`, verifies those checksums, emits GitHub build-provenance attestations, and publishes SBOM/provenance-bearing OCI manifests. The nightly workflow is validation-only and cannot publish public artifacts.
+The release workflow fails closed against the selected trust policy: `signed` requires credentials and verifies native trust, while `unsigned-beta` disables certificate discovery and requires an attested disclosure. It publishes only after all three desktop platforms and both architectures of both container images pass, creates `SHA256SUMS`, verifies those checksums, emits GitHub build-provenance attestations, and publishes SBOM/provenance-bearing OCI manifests. Validation-only release runs and the nightly workflow cannot publish public artifacts.
+
+After first deployment, temporarily set `BETA_TURN_USERNAME` and `BETA_TURN_PASSWORD` as Actions secrets and dispatch `validate-public-deployment.yml` with the exact public HTTPS origin and TURN URL. Its GitHub-hosted Chromium establishes relay-only data channels over both UDP and TCP and uploads sanitized evidence. Delete the temporary Actions secrets after the run; a local browser or a client on the TURN host's own network is not external evidence.
 
 ## Code gates
 
@@ -112,7 +112,7 @@ for artifact in Vesper-* vesper_* latest*.yml *.blockmap SHA256SUMS; do
 done
 ```
 
-Also verify the macOS code signature/notarization and Windows Authenticode signature before distributing links. Linux AppImage/deb artifacts do not have a separate native platform signature in this workflow; they rely on `SHA256SUMS` plus GitHub provenance. A checksum proves integrity relative to the release manifest; native signatures and provenance establish who produced it.
+For a `signed` release, also verify the macOS Developer ID signature/notarization and Windows Authenticode signature before distributing links. For `unsigned-beta`, verify that GitHub marks the release as a prerelease, that `UNSIGNED-NATIVE-BUILDS.txt` is present in `SHA256SUMS` and the provenance set, and that release notes clearly warn about Gatekeeper/SmartScreen. Linux AppImage/deb artifacts do not have a separate native platform signature in either mode; they rely on `SHA256SUMS` plus GitHub provenance. A checksum proves integrity relative to the release manifest, provenance identifies the producing workflow, and only native signatures establish native platform trust.
 
 Resolve and pin the published container digests rather than relying on a mutable tag:
 


### PR DESCRIPTION
## Why

Vesper v0.1.0 used GitHub-hosted macOS and Windows builders without Developer ID or Authenticode credentials. The new signed-only v0.2.0 gate accidentally turned an improved trust policy into an impossible infrastructure prerequisite. This keeps native trust honest without blocking the beta.

## What changed

- adds a validation-only mode that runs the full exact-source platform/container matrix from `main` before an immutable tag exists
- adds explicit `signed` and `unsigned-beta` policies
- forces unsigned native publication to prerelease status and ships a checksummed/attested warning
- retains signatures/notarization as fail-closed requirements in signed mode
- adds GitHub-hosted Chromium validation of relay-only TURN payloads over UDP and TCP
- updates release, deployment, CI, and security documentation

## Local evidence

- `actionlint .github/workflows/*.yml`
- `node --check client/scripts/test-external-turn.mjs`
- `./scripts/pre-commit-checks.sh` (server 179/179; client typecheck and web build)
- `git diff --check`

No tag, release, or deployment is created by this PR.