### PR TITLE
Fix wrapped release disclosure check

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -195,9 +195,10 @@ jobs:
             gh api -H 'Accept: application/octet-stream' \
               "repos/$GITHUB_REPOSITORY/releases/assets/$disclosure_id" \
               > /tmp/UNSIGNED-NATIVE-BUILDS.txt
-            grep -Fq 'not signed with Apple Developer ID or Windows Authenticode certificates' \
+            grep -Fq 'signed with Apple Developer ID or Windows Authenticode certificates,' \
               /tmp/UNSIGNED-NATIVE-BUILDS.txt
-            grep -Fq 'do not replace native platform trust' /tmp/UNSIGNED-NATIVE-BUILDS.txt
+            grep -Fq 'native platform trust or remove Gatekeeper/SmartScreen warnings.' \
+              /tmp/UNSIGNED-NATIVE-BUILDS.txt
           fi
           gh api -H 'Accept: application/octet-stream' \
             "repos/$GITHUB_REPOSITORY/releases/assets/$latest_windows_id" \


### PR DESCRIPTION
The partial-release recovery failed closed before checksums, container promotion, or publication because one disclosure assertion crossed a deliberate line wrap. This changes both assertions to complete stable lines from the already-attested `UNSIGNED-NATIVE-BUILDS.txt`.

Validated with `actionlint`, `bash -n` over every workflow run block, and the exact draft asset bytes. The three Windows draft assets were already renamed idempotently to match `latest.yml`; the release remains a 19-asset private draft.