### PR TITLE
Retry GHCR release manifest readback

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -355,6 +355,23 @@ jobs:
           release_version="${RELEASE_TAG#v}"
           mkdir -p /tmp/container-reconciliation
 
+          inspect_raw_with_retry() {
+            ref="$1"
+            destination="$2"
+            for attempt in $(seq 1 20); do
+              if docker buildx imagetools inspect --raw "$ref" \
+                > "${destination}.tmp" 2> /tmp/imagetools-inspect.err \
+                && test -s "${destination}.tmp"; then
+                mv "${destination}.tmp" "$destination"
+                return 0
+              fi
+              sleep 2
+            done
+            cat /tmp/imagetools-inspect.err >&2
+            echo "Registry did not expose $ref after 20 attempts" >&2
+            return 1
+          }
+
           for image in app web; do
             for arch in amd64 arm64; do
               ref="ghcr.io/${GITHUB_REPOSITORY}-${image}:candidate-${SOURCE_RUN_ID}-${arch}"
@@ -396,7 +413,7 @@ jobs:
                 --tag "$final_ref" \
                 "${candidate_base}-amd64" \
                 "${candidate_base}-arm64"
-              docker buildx imagetools inspect --raw "$final_ref" > "$final_raw"
+              inspect_raw_with_retry "$final_ref" "$final_raw"
             fi
 
             python3 - "$image" <<'PY'


### PR DESCRIPTION
GHCR accepted the exact `vesper-app:0.2.0` multi-architecture index, then returned exit 255 to an immediate read within ~0.4 seconds. The draft remained private, the checksum set was untouched, and `vesper-web:0.2.0` was never created.

This adds a bounded 20×2s read-after-write retry. Existing final tags still take the immutable path and must exactly equal the candidate descriptor union; they are never overwritten. The already-created app index was independently verified as the exact four-descriptor union (amd64 + provenance/SBOM, arm64 + provenance/SBOM).

Validated with `actionlint`, `bash -n` over every run block, exact app manifest comparison, and confirmation that the web tag remains unused.