### PR TITLE
Preserve immutable tag identity on draft updates

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -124,8 +124,11 @@ jobs:
             exit 1
           }
           jq '.[0]' /tmp/release-matches.json > /tmp/release.json
-          jq -e --arg tag "$RELEASE_TAG" \
-            '.tag_name == $tag and .draft == true and (.assets | length > 0)' \
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
+            '.tag_name == $tag
+             and .target_commitish == $sha
+             and .draft == true
+             and (.assets | length > 0)' \
             /tmp/release.json >/dev/null
           if [ "$SIGNING_MODE" = unsigned-beta ]; then
             jq -e '.prerelease == true' /tmp/release.json >/dev/null
@@ -302,11 +305,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
           SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
           if [ "$SIGNING_MODE" = unsigned-beta ]; then
             python3 <<'PY'
           import json
+          import os
           import pathlib
 
           release = json.loads(pathlib.Path('/tmp/release.json').read_text())
@@ -326,13 +331,19 @@ jobs:
           body = release.get('body') or ''
           if not body.startswith(warning):
               body = warning + body
-          pathlib.Path('/tmp/release-notes.json').write_text(json.dumps({'body': body}))
+          pathlib.Path('/tmp/release-notes.json').write_text(json.dumps({
+              'body': body,
+              'tag_name': os.environ['RELEASE_TAG'],
+              'target_commitish': os.environ['TAG_COMMIT'],
+          }))
           PY
             gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
               --input /tmp/release-notes.json >/dev/null
           fi
           gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-after-notes.json
-          jq -e '.draft == true' /tmp/release-after-notes.json >/dev/null
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
+            '.tag_name == $tag and .target_commitish == $sha and .draft == true' \
+            /tmp/release-after-notes.json >/dev/null
           if [ "$SIGNING_MODE" = unsigned-beta ]; then
             jq -e '.body | startswith("> [!WARNING]")' /tmp/release-after-notes.json >/dev/null
           fi
@@ -547,12 +558,14 @@ jobs:
               /tmp/release-before-publish.json >/dev/null
           fi
 
-          printf '{"draft":false}' > /tmp/publish-release.json
+          jq -n --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
+            '{draft: false, tag_name: $tag, target_commitish: $sha}' \
+            > /tmp/publish-release.json
           gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             --input /tmp/publish-release.json >/dev/null
           gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-published.json
-          jq -e --arg tag "$RELEASE_TAG" \
-            '.tag_name == $tag and .draft == false' \
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
+            '.tag_name == $tag and .target_commitish == $sha and .draft == false' \
             /tmp/release-published.json >/dev/null
 
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -613,11 +613,17 @@ jobs:
               printf '%s\n\n' '> This public beta contains unsigned Windows and unnotarized macOS builds. See `UNSIGNED-NATIVE-BUILDS.txt` before installing.'
               cat /tmp/generated-notes.md
             } > /tmp/release-notes.md
-            jq -Rs '{body: .}' /tmp/release-notes.md > /tmp/release-notes.json
+            jq -Rs --arg tag "$RELEASE_TAG" --arg sha "$GITHUB_SHA" \
+              '{body: ., tag_name: $tag, target_commitish: $sha}' \
+              /tmp/release-notes.md > /tmp/release-notes.json
             gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
               --input /tmp/release-notes.json >/dev/null
           fi
 
+          release_state="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$GITHUB_SHA" \
+            '.tag_name == $tag and .target_commitish == $sha and .draft == true' \
+            <<< "$release_state" >/dev/null
           local_count="$(find release-assets -maxdepth 1 -type f | wc -l)"
           remote_count="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" --jq '.assets | length')"
           test "$local_count" = "$remote_count"
@@ -654,6 +660,8 @@ jobs:
           test "$(jq 'length' <<< "$release_json")" = 1
           release_id="$(jq -r '.[0].id' <<< "$release_json")"
           test "$(jq -r '.[0].draft' <<< "$release_json")" = true
-          printf '{"draft":false}' > /tmp/publish-release.json
+          jq -n --arg tag "$RELEASE_TAG" --arg sha "$GITHUB_SHA" \
+            '{draft: false, tag_name: $tag, target_commitish: $sha}' \
+            > /tmp/publish-release.json
           gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
             --input /tmp/publish-release.json >/dev/null


### PR DESCRIPTION
GitHub changed the private draft from `v0.2.0` to an internal `untagged-*` identity when the recovery workflow patched only its body. The Git tag itself never moved. I reattached the draft to `v0.2.0` / `6f4704fb...` and confirmed that a PATCH carrying `tag_name` plus `target_commitish` preserves it.

This change makes both the normal release workflow and recovery workflow carry and re-verify the exact tag+commit on every release PATCH, including final publication. Recovery now also rejects a draft whose target identity is not exact.

No artifact, checksum, or container bytes change. The draft remains private; the exact app OCI index exists and was independently verified; the web release tag remains unused. Validated with `actionlint`, `bash -n` over every run block, and a live identity-preserving PATCH against the draft.