### PR TITLE
Separate release reconciliation from privileged publication

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -300,7 +300,7 @@ jobs:
           fi
           printf 'checksum_rewrite=%s\n' "$(cat /tmp/checksum-rewrite)" >> "$GITHUB_OUTPUT"
 
-      - name: Add or verify native trust disclosure
+      - name: Verify native trust disclosure
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -308,44 +308,23 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
-          if [ "$SIGNING_MODE" = unsigned-beta ]; then
-            python3 <<'PY'
-          import json
-          import os
-          import pathlib
-
-          release = json.loads(pathlib.Path('/tmp/release.json').read_text())
-          warning = (
-              '> [!WARNING]\n'
-              '> This public beta contains unsigned Windows and unnotarized macOS builds. '
-              'See `UNSIGNED-NATIVE-BUILDS.txt` before installing.\n'
-          )
-          if pathlib.Path('/tmp/checksum-rewrite').read_text().strip() == 'true':
-              warning += (
-                  '>\n'
-                  '> `SHA256SUMS` uses the final GitHub asset names. '
-                  '`SHA256SUMS.build-names` preserves the exact build-time '
-                  'checksum manifest covered by the source release attestation.\n'
-              )
-          warning += '\n'
-          body = release.get('body') or ''
-          if not body.startswith(warning):
-              body = warning + body
-          pathlib.Path('/tmp/release-notes.json').write_text(json.dumps({
-              'body': body,
-              'tag_name': os.environ['RELEASE_TAG'],
-              'target_commitish': os.environ['TAG_COMMIT'],
-          }))
-          PY
-            gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-              --input /tmp/release-notes.json >/dev/null
-          fi
+          # A main-branch GITHUB_TOKEN may mutate draft assets, but tag
+          # protection correctly rejects identity-bearing release PATCHes.
+          # Keep the draft private here; privileged publication happens only
+          # after this workflow has reconciled and verified every artifact.
           gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-after-notes.json
           jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
             '.tag_name == $tag and .target_commitish == $sha and .draft == true' \
             /tmp/release-after-notes.json >/dev/null
           if [ "$SIGNING_MODE" = unsigned-beta ]; then
-            jq -e '.body | startswith("> [!WARNING]")' /tmp/release-after-notes.json >/dev/null
+            jq -e \
+              '.body | startswith("> [!WARNING]\n> This public beta contains unsigned Windows and unnotarized macOS builds.")' \
+              /tmp/release-after-notes.json >/dev/null
+            if [ "${{ steps.release.outputs.checksum_rewrite }}" = true ]; then
+              jq -e \
+                '.body | contains("`SHA256SUMS.build-names` preserves the exact build-time checksum manifest")' \
+                /tmp/release-after-notes.json >/dev/null
+            fi
           fi
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -541,7 +520,7 @@ jobs:
             --format json > /tmp/canonical-attestation-verification.json
           test "$(jq 'length' /tmp/canonical-attestation-verification.json)" -ge 1
 
-      - name: Make the reconciled release public
+      - name: Verify release ready for privileged publication
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -549,35 +528,27 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-before-publish.json
-          jq -e --arg tag "$RELEASE_TAG" \
-            '.tag_name == $tag and .draft == true' \
-            /tmp/release-before-publish.json >/dev/null
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-ready.json
+          jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
+            '.tag_name == $tag and .target_commitish == $sha and .draft == true' \
+            /tmp/release-ready.json >/dev/null
           if [ "$SIGNING_MODE" = unsigned-beta ]; then
             jq -e '.prerelease == true and (.body | startswith("> [!WARNING]"))' \
-              /tmp/release-before-publish.json >/dev/null
+              /tmp/release-ready.json >/dev/null
           fi
 
-          jq -n --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
-            '{draft: false, tag_name: $tag, target_commitish: $sha}' \
-            > /tmp/publish-release.json
-          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            --input /tmp/publish-release.json >/dev/null
-          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > /tmp/release-published.json
-          jq -e --arg tag "$RELEASE_TAG" --arg sha "$TAG_COMMIT" \
-            '.tag_name == $tag and .target_commitish == $sha and .draft == false' \
-            /tmp/release-published.json >/dev/null
-
           {
-            echo '## Release reconciliation complete'
+            echo '## Release reconciliation ready for privileged publication'
             echo
             printf -- '- Tag commit: `%s`\n' "$TAG_COMMIT"
             printf -- '- Source run: `%s`\n' "${{ inputs.source_run_id }}"
-            printf -- '- Release: %s\n' "$(jq -r '.html_url' /tmp/release-published.json)"
+            printf -- '- Draft release ID: `%s`\n' "$RELEASE_ID"
             printf -- '- App image: `ghcr.io/%s-app:%s@%s`\n' \
               "$GITHUB_REPOSITORY" "${RELEASE_TAG#v}" "${{ steps.containers.outputs.app_digest }}"
             printf -- '- Web image: `ghcr.io/%s-web:%s@%s`\n' \
               "$GITHUB_REPOSITORY" "${RELEASE_TAG#v}" "${{ steps.containers.outputs.web_digest }}"
+            echo
+            echo 'The draft remains private. Publish only with an owner token while resending the exact tag and target commit.'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload reconciliation evidence
@@ -588,7 +559,7 @@ jobs:
           path: |
             /tmp/source-run.json
             /tmp/source-jobs.json
-            /tmp/release-published.json
+            /tmp/release-ready.json
             /tmp/SHA256SUMS
             /tmp/SHA256SUMS.build-source
             /tmp/attestation-verification.json


### PR DESCRIPTION
A main-branch `GITHUB_TOKEN` can mutate draft assets but correctly cannot submit an identity-bearing release PATCH under the repository tag rules. The recovery therefore failed closed before any additional container/checksum work.

This removes release-metadata mutation from the main-branch recovery path. Actions now verifies the existing disclosure, reconciles and attests the canonical checksum index, verifies/promotes exact OCI candidates, and leaves a private ready-state draft. Final publication is one owner-token PATCH that must resend `tag_name=v0.2.0` and target `6f4704fb...`, followed by independent verification.

The current draft is reattached to the exact immutable identity, remains private with 19 assets, and has the correct warning/checksum note. The app index is exact; web remains unused. Validated with `actionlint`, `bash -n`, and live draft-state checks.