### PR TITLE
Hash raw attested OCI indexes during reconciliation

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -430,10 +430,11 @@ jobs:
               raise SystemExit(f'{image} final manifest is missing a release platform')
           PY
 
-            manifest_digest="$(
-              docker buildx imagetools inspect "$final_ref" \
-                | awk '$1 == "Digest:" {print $2; exit}'
-            )"
+            # The human-readable Buildx renderer exits 255 on indexes that
+            # contain BuildKit attestation descriptors even though --raw is
+            # valid. The OCI index digest is the SHA-256 of those exact raw
+            # manifest bytes already checked above.
+            manifest_digest="sha256:$(sha256sum "$final_raw" | cut -d' ' -f1)"
             [[ "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
             printf '%s=%s\n' "$image" "$manifest_digest" >> /tmp/container-reconciliation/digests.env
             printf '%s_digest=%s\n' "$image" "$manifest_digest" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The recovery verified all candidate labels/platforms and the exact app descriptor union, then Buildx’s human-readable renderer exited 255 on the valid index because it includes BuildKit attestation descriptors. This is downstream of the security check and does not indicate an invalid image.

Use SHA-256 over the already-fetched raw OCI index bytes for the summary/output digest, avoiding the incompatible renderer. The app release index remains exact and immutable; web remains unused; the release stays a 19-asset private draft. `actionlint` and every Bash block pass.